### PR TITLE
Simplify vault: one checkout per niche, explicit merge semantics (#80)

### DIFF
--- a/branch-plan.md
+++ b/branch-plan.md
@@ -28,42 +28,41 @@ Remove DVCS features from Shared File Vault whose complexity cost exceeds their 
 - Remove (or simplify) the multi-checkout refresh loop in `publish()`, `pull_niche()`, and `merge_niche()` — with at most one checkout, this reduces to a direct single-checkout refresh.
 - Add a helper `get_checkout(vault_root, participant_hex, team_name, niche_name) -> str | None` that returns the single checkout path (or None).
 
-### 2. Eliminate the transit work tree
-
-The transit work tree existed to solve two problems: (a) multiple checkouts needing a neutral merge space, and (b) user checkouts potentially being dirty at merge time. This branch eliminates both problems, so transit can be removed entirely.
+### 2. Fetch/merge semantics after simplification
 
 Post-simplification model:
-- **fetch**: operates on the bare git dir only, no work tree required, always available regardless of checkout state.
-- **merge/pull**: requires a checkout to exist (returns a clear error if none), merges directly into the user's checkout since it is guaranteed clean.
+- **fetch**: may happen automatically in the background and may also be triggered explicitly by the user. It gathers peer updates without changing the user's checkout contents.
+- **merge**: remains a separate explicit action. Merge is the moment when fetched peer updates are applied to local visible state.
+- **pull**: if retained in the CLI, it is only a convenience wrapper for `fetch + merge`, not a distinct model.
 
-The `_cod_pull()` / `_cod_fetch()` / `_cod_merge_ref()` functions in `vault.py` were largely built around the transit work tree and should be rewritten as simpler functions targeting the bare git dir and the single user checkout directly.
+Edge case: **niche not materialized locally.** If a peer pushes while no checkout is attached, fetch is still allowed and should park the fetched refs locally. Later attaching a checkout does **not** auto-merge those parked refs. The user must still perform an explicit merge after attach. This is the least surprising first implementation and keeps "materialize files" separate from "integrate fetched changes."
 
-Edge case: **niche not materialized locally.** If a peer pushes while no checkout is attached, fetch still works fine (bare git dir). Merge is simply unavailable and should return a clear error. When the user later attaches a checkout, `add_checkout()` initializes the work tree from current HEAD — no deferred merge required. Multiple un-merged peer refs accumulating while there is no checkout is not a blocker for this branch; it can be addressed later.
+This branch intentionally does **not** require architectural garbage collection of the transit work tree or adjacent Cod Sync helper complexity. That cleanup remains desirable, but it will be tracked as a follow-up issue instead of broadening this branch.
 
-### 3. Require clean checkout before pull/merge in `vault.py`
+### 3. Require clean checkout before merge in `vault.py`
 
 - Add `_is_checkout_clean(checkout_path, git_dir) -> bool` that runs `git status --porcelain` scoped to the user's checkout work tree. **Important:** always pass the user's checkout path explicitly — do not let this check accidentally target the transit or any other work tree.
-- `--porcelain` output includes untracked files. Untracked files block pull/merge just like tracked changes do. The primary motivation is UX simplicity: non-git users have no mental model for the tracked/untracked distinction, so "your folder must be clean" is one rule rather than a leaky git abstraction. Path-collision safety is a secondary benefit. This diverges from git's default merge behavior and should be noted in the function doc. Future relaxation (e.g. ignoring certain noise files) can be motivated by specific cases.
-- In `pull_niche()` (and `merge_niche()`): before doing any network/merge work, call this check. Raise a new `DirtyCheckoutError` (with the list of modified paths) if unclean.
+- `--porcelain` output includes untracked files. Untracked files block merge-time operations just like tracked changes do. The primary motivation is UX simplicity: non-git users have no mental model for the tracked/untracked distinction, so "your folder must be clean" is one rule rather than a leaky git abstraction. Path-collision safety is a secondary benefit. This diverges from git's default merge behavior and should be noted in the function doc. Future relaxation (e.g. ignoring certain noise files) can be motivated by specific cases.
+- In `merge_niche()` (and any combined `pull` wrapper): before doing merge work, call this check. Raise a new `DirtyCheckoutError` (with the list of modified paths) if unclean.
 - Do the same in `pull_registry()` / `merge_registry()`.
-- Mirror this guard in `sync.py`'s `pull_via_hub()` and `merge_via_hub()`.
-- `fetch_niche()` does not need the clean-checkout guard (fetch touches only the bare git dir). The guard lives in `merge_niche()`. The UI model (banner-then-deliberate-merge) means the user naturally has time to clean up between seeing changes are available and attempting to merge.
-- Do not add a partial "discard tracked files only" path in this branch. Pull requires a genuinely clean checkout; any destructive cleanup action should be a separate explicit feature.
+- Mirror this guard in `sync.py`'s combined/wrapper operations and `merge_via_hub()`.
+- `fetch_niche()` does not need the clean-checkout guard because fetch alone does not change visible checkout state. The guard lives in merge-time paths. The UI model (background-or-manual fetch, then deliberate merge) gives the user a natural window to clean up before integrating changes.
+- Do not add a partial "discard tracked files only" path in this branch. Merge-capable flows require a genuinely clean checkout; any destructive cleanup action should be a separate explicit feature.
 
 ### 4. Update `web.py` and templates
 
 - Remove the "add another checkout" form from `checkouts.html` / `niche_detail.html` — replace it with a single checkout path display, a remove action, and an attach form that is only available when no checkout exists.
 - Keep the `POST .../checkouts` route as an explicit attach action, not an implicit replace. If a checkout already exists, return an error that tells the user to remove it first.
 - Simplify niche detail view: instead of iterating over checkouts, show the single checkout path (or a prompt to attach one).
-- The fetch→merge flow should not present as a single button that immediately leads to merge. Instead: fetch surfaces a "Changes from teammates available" banner or indicator; merge is a separate deliberate action the user takes when ready. This gives the user a natural window to clean up their work tree before merging, making the dirty-checkout error less surprising when it fires.
-- Whether fetch becomes automatic (on page load, background poll) or stays a manual trigger is a decision to make during implementation; flag it and decide explicitly rather than inheriting the current behavior by default.
+- The fetch→merge flow should not present as a single button that immediately leads to merge. Instead: background fetch and explicit "check now" fetch both surface a "Changes from teammates available" banner or indicator; merge is a separate deliberate action the user takes when ready. This gives the user a natural window to clean up their work tree before merging, making the dirty-checkout error less surprising when it fires.
 - Surface `DirtyCheckoutError` when merge is rejected — show which files are dirty and direct the user to publish or manually clean the work tree. Do not add an in-branch "move checkout" or destructive auto-clean flow.
 
 ### 5. Update `cli.py`
 
 - Audit all CLI commands that mention checkouts; update help text and behavior to match single-checkout semantics.
 - `checkout` command should fail clearly if the niche already has a checkout and explain that the user must remove it first.
-- `pull` command: surface `DirtyCheckoutError` with a clear message about what the user needs to do.
+- Keep separate `fetch` and `merge` semantics conceptually clear. If the CLI keeps a `pull` command, document it as a convenience wrapper for `fetch + merge`.
+- Any merge-capable CLI path should surface `DirtyCheckoutError` with a clear message about what the user needs to do.
 
 ### 6. Update `spec.md`
 
@@ -71,14 +70,14 @@ Edge case: **niche not materialized locally.** If a peer pushes while no checkou
 - Document the new constraint: "at most one checkout per niche per device."
 - Document the new pull pre-condition: "checkout must be clean."
 
-### 6. Update tests
+### 7. Update tests
 
 - Remove `test_add_multiple_checkouts`, `test_publish_refreshes_sibling_checkouts`, `test_multiple_checkouts_same_niche` (or convert to tests that verify the new error is raised).
 - Add micro tests:
   - `test_add_checkout_twice_raises()` — second `add_checkout` on same niche errors.
-  - `test_pull_dirty_checkout_raises()` — pull with uncommitted changes raises `DirtyCheckoutError`.
-  - `test_pull_clean_checkout_succeeds()` — baseline pull still works.
-  - `test_merge_dirty_checkout_raises()` — same guard for merge.
+  - `test_merge_dirty_checkout_raises()` — merge with uncommitted changes raises `DirtyCheckoutError`.
+  - `test_fetch_then_merge_clean_checkout_succeeds()` — baseline fetch+merge still works.
+  - `test_merge_without_checkout_raises()` — parked updates cannot be merged into visible state until a checkout exists.
 - Update `test_aspirational.py` scenarios to reflect single-checkout reality.
 
 ---
@@ -91,6 +90,15 @@ Edge case: **niche not materialized locally.** If a peer pushes while no checkou
 
 3. **No migration work; recreate local checkout metadata.** `checkouts.db` is device-local and reconstructable. For this pre-alpha branch we should add/keep schema version markers, but on mismatch simply recreate the local DB instead of writing compatibility migrations.
 
+4. **Transit/code-complexity cleanup is deferred.** This branch should simplify the user-visible model and the branch-local invariants first. Cleaning up transit work trees and adjacent Cod Sync helper complexity is valuable, but it should be tracked as a separate follow-up issue rather than being a prerequisite for this branch.
+
+5. **Automatic fetch is desired; merge stays explicit.** The product model should allow the app to fetch under the hood and also let the user ask to check right now. Either way, fetched changes do not become visible local state until the user explicitly merges.
+
+6. **Follow-up work should be explicit GitHub issues.** This branch should create three follow-up issues:
+   1. three-mode niche residency (`checked out`, `cached but not checked out`, `remote only`)
+   2. garbage-collect transit work tree / git-tree complexity and simplify related sync code
+   3. research and implement mitigations for incidental conflicts / benign noise
+
 ## Validation
 
 This branch should convince a skeptical reviewer if all of the following are
@@ -98,9 +106,10 @@ true:
 
 - a niche can have at most one local checkout on a device, enforced both in Python code and in the SQLite schema
 - attempts to attach a second checkout fail explicitly instead of silently replacing or partially mutating local state
-- pull and merge operations refuse to run when the relevant checkout is dirty, and they report which paths are blocking progress
+- merge-time operations refuse to run when the relevant checkout is dirty, and they report which paths are blocking progress
 - the branch does not add hidden destructive behavior such as partial discard, silent checkout moves, or schema-migration complexity
 - the `.git`-separate-from-checkout-directory design remains intact
+- fetched updates may be parked locally without a checkout, and attaching a checkout later still requires an explicit merge before those parked updates become visible files
 - Shared File Vault behavior becomes simpler rather than more coupled: single-checkout helpers replace list-oriented logic where possible, and UI/CLI language matches runtime reality
 - updated micro tests cover both happy paths and refusal paths, especially the ones most likely to regress the new invariants
 
@@ -108,23 +117,26 @@ true:
 
 - micro tests showing `add_checkout()` succeeds once and then fails on a second checkout for the same niche
 - micro tests showing the DB schema rejects duplicate `(team_name, niche_name)` checkout rows
-- micro tests showing `pull_niche()` and `merge_niche()` reject dirty tracked changes
-- micro tests showing dirty untracked files also block pull/merge, so we do not hide collision cases behind partial cleanup
-- micro tests showing clean pull/merge still refresh the single checkout correctly
+- micro tests showing fetch can park updates without an attached checkout
+- micro tests showing attaching a checkout after fetch does not auto-merge parked updates
+- micro tests showing merge-time paths reject dirty tracked changes
+- micro tests showing dirty untracked files also block merge, so we do not hide collision cases behind partial cleanup
+- micro tests showing clean fetch/merge still refresh the single checkout correctly
 - web and CLI tests showing the user sees a clear "remove existing checkout first" message instead of implicit replacement
 - web and CLI tests showing `DirtyCheckoutError` is surfaced with actionable guidance
 - spec and aspirational test updates showing the product model now says "one checkout per niche per device" rather than preserving the old multi-checkout story
+- wrap-up evidence includes filing the three intended follow-up GitHub issues so scope boundaries remain explicit
 
 ---
 
 ## Order of Work
 
 1. `vault.py` — local schema/version handling, one-checkout uniqueness enforcement, and `get_checkout` helper
-2. `vault.py` — remove transit work tree; rewrite `_cod_pull/fetch/merge_ref` to target bare git dir + single user checkout directly
-3. `vault.py` — `DirtyCheckoutError` + `_is_checkout_clean` + guards in pull/merge (not fetch)
-4. `sync.py` — propagate dirty-checkout guard through Hub-backed wrappers
-5. Micro tests for the new invariants and refusal paths
-6. `web.py` + templates — single-checkout UI, explicit remove-then-attach semantics, dirty-checkout error surfacing
-7. `cli.py` — audit and update
-8. `spec.md` — update documentation, remove multi-checkout and transit claims
-9. Aspirational tests — update/remove multi-checkout scenarios
+2. `vault.py` / `sync.py` — preserve explicit fetch-vs-merge semantics, including parked updates without checkout and explicit merge after attach
+3. `vault.py` — `DirtyCheckoutError` + `_is_checkout_clean` + guards in merge-time paths
+4. Micro tests for the new invariants and refusal paths
+5. `web.py` + templates — single-checkout UI, automatic-plus-manual fetch, explicit merge, dirty-checkout error surfacing
+6. `cli.py` — audit and update, keeping any `pull` command as a documented convenience wrapper only
+7. `spec.md` — update documentation, remove multi-checkout claims, and document parked-fetch/explicit-merge behavior
+8. Aspirational tests — update/remove multi-checkout scenarios
+9. File follow-up GitHub issues for niche residency modes, transit/code-complexity cleanup, and incidental-conflict mitigation

--- a/branch-plan.md
+++ b/branch-plan.md
@@ -28,28 +28,44 @@ Remove DVCS features from Shared File Vault whose complexity cost exceeds their 
 - Remove (or simplify) the multi-checkout refresh loop in `publish()`, `pull_niche()`, and `merge_niche()` — with at most one checkout, this reduces to a direct single-checkout refresh.
 - Add a helper `get_checkout(vault_root, participant_hex, team_name, niche_name) -> str | None` that returns the single checkout path (or None).
 
-### 2. Require clean checkout before pull/merge in `vault.py`
+### 2. Eliminate the transit work tree
 
-- Add `_is_checkout_clean(git_dir, checkout_path) -> bool` that checks `git status --porcelain` for the checkout's work tree.
+The transit work tree existed to solve two problems: (a) multiple checkouts needing a neutral merge space, and (b) user checkouts potentially being dirty at merge time. This branch eliminates both problems, so transit can be removed entirely.
+
+Post-simplification model:
+- **fetch**: operates on the bare git dir only, no work tree required, always available regardless of checkout state.
+- **merge/pull**: requires a checkout to exist (returns a clear error if none), merges directly into the user's checkout since it is guaranteed clean.
+
+The `_cod_pull()` / `_cod_fetch()` / `_cod_merge_ref()` functions in `vault.py` were largely built around the transit work tree and should be rewritten as simpler functions targeting the bare git dir and the single user checkout directly.
+
+Edge case: **niche not materialized locally.** If a peer pushes while no checkout is attached, fetch still works fine (bare git dir). Merge is simply unavailable and should return a clear error. When the user later attaches a checkout, `add_checkout()` initializes the work tree from current HEAD — no deferred merge required. Multiple un-merged peer refs accumulating while there is no checkout is not a blocker for this branch; it can be addressed later.
+
+### 3. Require clean checkout before pull/merge in `vault.py`
+
+- Add `_is_checkout_clean(checkout_path, git_dir) -> bool` that runs `git status --porcelain` scoped to the user's checkout work tree. **Important:** always pass the user's checkout path explicitly — do not let this check accidentally target the transit or any other work tree.
+- `--porcelain` output includes untracked files. Untracked files block pull/merge just like tracked changes do. The primary motivation is UX simplicity: non-git users have no mental model for the tracked/untracked distinction, so "your folder must be clean" is one rule rather than a leaky git abstraction. Path-collision safety is a secondary benefit. This diverges from git's default merge behavior and should be noted in the function doc. Future relaxation (e.g. ignoring certain noise files) can be motivated by specific cases.
 - In `pull_niche()` (and `merge_niche()`): before doing any network/merge work, call this check. Raise a new `DirtyCheckoutError` (with the list of modified paths) if unclean.
 - Do the same in `pull_registry()` / `merge_registry()`.
 - Mirror this guard in `sync.py`'s `pull_via_hub()` and `merge_via_hub()`.
-- Do not add a partial "discard tracked files only" path in this branch. For now, pulling requires an actually clean checkout; any future destructive cleanup action should be an explicit separate feature.
+- `fetch_niche()` does not need the clean-checkout guard (fetch touches only the bare git dir). The guard lives in `merge_niche()`. The UI model (banner-then-deliberate-merge) means the user naturally has time to clean up between seeing changes are available and attempting to merge.
+- Do not add a partial "discard tracked files only" path in this branch. Pull requires a genuinely clean checkout; any destructive cleanup action should be a separate explicit feature.
 
-### 3. Update `web.py` and templates
+### 4. Update `web.py` and templates
 
 - Remove the "add another checkout" form from `checkouts.html` / `niche_detail.html` — replace it with a single checkout path display, a remove action, and an attach form that is only available when no checkout exists.
 - Keep the `POST .../checkouts` route as an explicit attach action, not an implicit replace. If a checkout already exists, return an error that tells the user to remove it first.
 - Simplify niche detail view: instead of iterating over checkouts, show the single checkout path (or a prompt to attach one).
-- Surface `DirtyCheckoutError` in the UI when a pull is rejected — show which files are dirty and direct the user to publish, manually clean the work tree, or remove the checkout. Do not add an in-branch "move checkout" or destructive auto-clean flow.
+- The fetch→merge flow should not present as a single button that immediately leads to merge. Instead: fetch surfaces a "Changes from teammates available" banner or indicator; merge is a separate deliberate action the user takes when ready. This gives the user a natural window to clean up their work tree before merging, making the dirty-checkout error less surprising when it fires.
+- Whether fetch becomes automatic (on page load, background poll) or stays a manual trigger is a decision to make during implementation; flag it and decide explicitly rather than inheriting the current behavior by default.
+- Surface `DirtyCheckoutError` when merge is rejected — show which files are dirty and direct the user to publish or manually clean the work tree. Do not add an in-branch "move checkout" or destructive auto-clean flow.
 
-### 4. Update `cli.py`
+### 5. Update `cli.py`
 
 - Audit all CLI commands that mention checkouts; update help text and behavior to match single-checkout semantics.
 - `checkout` command should fail clearly if the niche already has a checkout and explain that the user must remove it first.
 - `pull` command: surface `DirtyCheckoutError` with a clear message about what the user needs to do.
 
-### 5. Update `spec.md`
+### 6. Update `spec.md`
 
 - Remove or mark deprecated the multi-checkout description.
 - Document the new constraint: "at most one checkout per niche per device."
@@ -104,10 +120,11 @@ true:
 ## Order of Work
 
 1. `vault.py` — local schema/version handling, one-checkout uniqueness enforcement, and `get_checkout` helper
-2. `vault.py` — `DirtyCheckoutError` + `_is_checkout_clean` + guards in pull/merge
-3. `sync.py` — propagate dirty-checkout guard
-4. Micro tests for the new invariants and refusal paths
-5. `web.py` + templates — single-checkout UI, explicit remove-then-attach semantics, and dirty-checkout error surfacing
-6. `cli.py` — audit and update
-7. `spec.md` — update documentation and remove multi-checkout claims
-8. Aspirational tests — update/remove multi-checkout scenarios
+2. `vault.py` — remove transit work tree; rewrite `_cod_pull/fetch/merge_ref` to target bare git dir + single user checkout directly
+3. `vault.py` — `DirtyCheckoutError` + `_is_checkout_clean` + guards in pull/merge (not fetch)
+4. `sync.py` — propagate dirty-checkout guard through Hub-backed wrappers
+5. Micro tests for the new invariants and refusal paths
+6. `web.py` + templates — single-checkout UI, explicit remove-then-attach semantics, dirty-checkout error surfacing
+7. `cli.py` — audit and update
+8. `spec.md` — update documentation, remove multi-checkout and transit claims
+9. Aspirational tests — update/remove multi-checkout scenarios

--- a/branch-plan.md
+++ b/branch-plan.md
@@ -4,7 +4,7 @@
 
 Remove DVCS features from Shared File Vault whose complexity cost exceeds their value:
 1. **At most one local checkout per niche** — a niche is either not materialized on a device or has exactly one checkout location.
-2. **Require clean checkout before pulling** — the user must commit or drop local changes before accepting changes from elsewhere.
+2. **Require clean checkout before merge-capable sync operations** — the user must commit or drop local changes before integrating fetched changes from elsewhere.
 3. **Keep the `.git`-separate-from-checkout-directory design.**
 
 ---
@@ -44,7 +44,7 @@ This branch intentionally does **not** require architectural garbage collection 
 - Add `_is_checkout_clean(checkout_path, git_dir) -> bool` that runs `git status --porcelain` scoped to the user's checkout work tree. **Important:** always pass the user's checkout path explicitly — do not let this check accidentally target the transit or any other work tree.
 - `--porcelain` output includes untracked files. Untracked files block merge-time operations just like tracked changes do. The primary motivation is UX simplicity: non-git users have no mental model for the tracked/untracked distinction, so "your folder must be clean" is one rule rather than a leaky git abstraction. Path-collision safety is a secondary benefit. This diverges from git's default merge behavior and should be noted in the function doc. Future relaxation (e.g. ignoring certain noise files) can be motivated by specific cases.
 - In `merge_niche()` (and any combined `pull` wrapper): before doing merge work, call this check. Raise a new `DirtyCheckoutError` (with the list of modified paths) if unclean.
-- Do the same in `pull_registry()` / `merge_registry()`.
+- Do the same for registry merge-time paths.
 - Mirror this guard in `sync.py`'s combined/wrapper operations and `merge_via_hub()`.
 - `fetch_niche()` does not need the clean-checkout guard because fetch alone does not change visible checkout state. The guard lives in merge-time paths. The UI model (background-or-manual fetch, then deliberate merge) gives the user a natural window to clean up before integrating changes.
 - Do not add a partial "discard tracked files only" path in this branch. Merge-capable flows require a genuinely clean checkout; any destructive cleanup action should be a separate explicit feature.

--- a/branch-plan.md
+++ b/branch-plan.md
@@ -119,7 +119,7 @@ true:
 - micro tests showing the DB schema rejects duplicate `(team_name, niche_name)` checkout rows
 - micro tests showing fetch can park updates without an attached checkout
 - micro tests showing attaching a checkout after fetch does not auto-merge parked updates
-- micro tests showing merge-time paths reject dirty tracked changes
+- micro tests showing merge-time paths reject dirty tracked changes — critically, these tests must put dirty files in the *user's checkout directory*, not in transit, and must verify the guard fires before any transit operations run (transit always resets itself to HEAD and would silently pass the check if tested there)
 - micro tests showing dirty untracked files also block merge, so we do not hide collision cases behind partial cleanup
 - micro tests showing clean fetch/merge still refresh the single checkout correctly
 - web and CLI tests showing the user sees a clear "remove existing checkout first" message instead of implicit replacement

--- a/branch-plan.md
+++ b/branch-plan.md
@@ -1,0 +1,113 @@
+# Branch Plan: Simplify Vault (Issue #80)
+
+## Goal
+
+Remove DVCS features from Shared File Vault whose complexity cost exceeds their value:
+1. **At most one local checkout per niche** — a niche is either not materialized on a device or has exactly one checkout location.
+2. **Require clean checkout before pulling** — the user must commit or drop local changes before accepting changes from elsewhere.
+3. **Keep the `.git`-separate-from-checkout-directory design.**
+
+---
+
+## Current State Summary
+
+- `checkouts.db` has a `checkout` table with no uniqueness constraint on `(team_name, niche_name)` — multiple checkouts are explicitly supported.
+- `pull_niche()` and `merge_niche()` refresh **all** registered checkouts after a successful merge. There is no "is checkout clean?" guard.
+- The web UI (`checkouts.html`, `niche_detail.html`) shows a list of checkouts, an "add checkout" form, and per-checkout "remove" buttons — all designed for the multi-checkout case.
+- Tests: `test_add_multiple_checkouts`, `test_publish_refreshes_sibling_checkouts`, `test_multiple_checkouts_same_niche` explicitly exercise multiple-checkout behavior.
+
+---
+
+## Planned Changes
+
+### 1. Enforce one-checkout-per-niche in `vault.py`
+
+- In `add_checkout()`: if a checkout already exists for `(team_name, niche_name)`, raise an error. The user must explicitly remove the old checkout before attaching a new one.
+- In the `checkout` table, add a UNIQUE constraint on `(team_name, niche_name)`.
+- Add an explicit local schema/version marker for `checkouts.db`, and on mismatch recreate the local DB from scratch instead of doing migration work.
+- Remove (or simplify) the multi-checkout refresh loop in `publish()`, `pull_niche()`, and `merge_niche()` — with at most one checkout, this reduces to a direct single-checkout refresh.
+- Add a helper `get_checkout(vault_root, participant_hex, team_name, niche_name) -> str | None` that returns the single checkout path (or None).
+
+### 2. Require clean checkout before pull/merge in `vault.py`
+
+- Add `_is_checkout_clean(git_dir, checkout_path) -> bool` that checks `git status --porcelain` for the checkout's work tree.
+- In `pull_niche()` (and `merge_niche()`): before doing any network/merge work, call this check. Raise a new `DirtyCheckoutError` (with the list of modified paths) if unclean.
+- Do the same in `pull_registry()` / `merge_registry()`.
+- Mirror this guard in `sync.py`'s `pull_via_hub()` and `merge_via_hub()`.
+- Do not add a partial "discard tracked files only" path in this branch. For now, pulling requires an actually clean checkout; any future destructive cleanup action should be an explicit separate feature.
+
+### 3. Update `web.py` and templates
+
+- Remove the "add another checkout" form from `checkouts.html` / `niche_detail.html` — replace it with a single checkout path display, a remove action, and an attach form that is only available when no checkout exists.
+- Keep the `POST .../checkouts` route as an explicit attach action, not an implicit replace. If a checkout already exists, return an error that tells the user to remove it first.
+- Simplify niche detail view: instead of iterating over checkouts, show the single checkout path (or a prompt to attach one).
+- Surface `DirtyCheckoutError` in the UI when a pull is rejected — show which files are dirty and direct the user to publish, manually clean the work tree, or remove the checkout. Do not add an in-branch "move checkout" or destructive auto-clean flow.
+
+### 4. Update `cli.py`
+
+- Audit all CLI commands that mention checkouts; update help text and behavior to match single-checkout semantics.
+- `checkout` command should fail clearly if the niche already has a checkout and explain that the user must remove it first.
+- `pull` command: surface `DirtyCheckoutError` with a clear message about what the user needs to do.
+
+### 5. Update `spec.md`
+
+- Remove or mark deprecated the multi-checkout description.
+- Document the new constraint: "at most one checkout per niche per device."
+- Document the new pull pre-condition: "checkout must be clean."
+
+### 6. Update tests
+
+- Remove `test_add_multiple_checkouts`, `test_publish_refreshes_sibling_checkouts`, `test_multiple_checkouts_same_niche` (or convert to tests that verify the new error is raised).
+- Add micro tests:
+  - `test_add_checkout_twice_raises()` — second `add_checkout` on same niche errors.
+  - `test_pull_dirty_checkout_raises()` — pull with uncommitted changes raises `DirtyCheckoutError`.
+  - `test_pull_clean_checkout_succeeds()` — baseline pull still works.
+  - `test_merge_dirty_checkout_raises()` — same guard for merge.
+- Update `test_aspirational.py` scenarios to reflect single-checkout reality.
+
+---
+
+## Resolved Decisions
+
+1. **Second `add_checkout` errors; it does not replace.** Under the hood the one-checkout invariant should be enforced by a real error, not a silent move. At the UX level, forcing the user to remove/detach the existing checkout before attaching a new one is acceptable for now. A dedicated "move checkout" workflow can come later if we still want it.
+
+2. **No special discard workflow in this branch.** The simplest honest rule is that pull/merge requires a clean checkout. We should not spend branch scope on a half-safe cleanup path. If we later add a destructive cleanup action, it should be explicit and should blow away tracked and untracked local changes together, with strong warnings.
+
+3. **No migration work; recreate local checkout metadata.** `checkouts.db` is device-local and reconstructable. For this pre-alpha branch we should add/keep schema version markers, but on mismatch simply recreate the local DB instead of writing compatibility migrations.
+
+## Validation
+
+This branch should convince a skeptical reviewer if all of the following are
+true:
+
+- a niche can have at most one local checkout on a device, enforced both in Python code and in the SQLite schema
+- attempts to attach a second checkout fail explicitly instead of silently replacing or partially mutating local state
+- pull and merge operations refuse to run when the relevant checkout is dirty, and they report which paths are blocking progress
+- the branch does not add hidden destructive behavior such as partial discard, silent checkout moves, or schema-migration complexity
+- the `.git`-separate-from-checkout-directory design remains intact
+- Shared File Vault behavior becomes simpler rather than more coupled: single-checkout helpers replace list-oriented logic where possible, and UI/CLI language matches runtime reality
+- updated micro tests cover both happy paths and refusal paths, especially the ones most likely to regress the new invariants
+
+## Validation Evidence To Gather In This Branch
+
+- micro tests showing `add_checkout()` succeeds once and then fails on a second checkout for the same niche
+- micro tests showing the DB schema rejects duplicate `(team_name, niche_name)` checkout rows
+- micro tests showing `pull_niche()` and `merge_niche()` reject dirty tracked changes
+- micro tests showing dirty untracked files also block pull/merge, so we do not hide collision cases behind partial cleanup
+- micro tests showing clean pull/merge still refresh the single checkout correctly
+- web and CLI tests showing the user sees a clear "remove existing checkout first" message instead of implicit replacement
+- web and CLI tests showing `DirtyCheckoutError` is surfaced with actionable guidance
+- spec and aspirational test updates showing the product model now says "one checkout per niche per device" rather than preserving the old multi-checkout story
+
+---
+
+## Order of Work
+
+1. `vault.py` — local schema/version handling, one-checkout uniqueness enforcement, and `get_checkout` helper
+2. `vault.py` — `DirtyCheckoutError` + `_is_checkout_clean` + guards in pull/merge
+3. `sync.py` — propagate dirty-checkout guard
+4. Micro tests for the new invariants and refusal paths
+5. `web.py` + templates — single-checkout UI, explicit remove-then-attach semantics, and dirty-checkout error surfacing
+6. `cli.py` — audit and update
+7. `spec.md` — update documentation and remove multi-checkout claims
+8. Aspirational tests — update/remove multi-checkout scenarios

--- a/packages/shared-file-vault/shared_file_vault/cli.py
+++ b/packages/shared-file-vault/shared_file_vault/cli.py
@@ -134,7 +134,7 @@ def push_cmd(team_name, niche_name, vault_root, participant, hub_port):
 @click.option("--participant", default=None, help="Override participant hex from config")
 @click.option("--hub-port", type=int, default=None, help="Override Hub port from config")
 def pull_cmd(team_name, niche_name, from_member, vault_root, participant, hub_port):
-    """Pull a niche and its registry from a peer through the Hub."""
+    """Pull a niche and its registry from a peer (fetch + merge)."""
     vault_root, participant, hub_port = _resolve_sync(vault_root, participant, hub_port)
     try:
         vault_root = sync.require_value(vault_root, "vault_root")
@@ -147,6 +147,15 @@ def pull_cmd(team_name, niche_name, from_member, vault_root, participant, hub_po
             from_member,
             hub_port=hub_port,
         )
+    except sync.DirtyCheckoutError as exc:
+        click.echo("Pull blocked: checkout has uncommitted changes.", err=True)
+        if exc.paths:
+            click.echo("Clean up these files before pulling:", err=True)
+            for path in exc.paths:
+                click.echo(f"  {path}", err=True)
+        raise SystemExit(1)
+    except sync.NoCheckoutError as exc:
+        _die(str(exc))
     except sync.PullConflictError as exc:
         click.echo(f"Pull left unresolved conflicts in the {exc.scope}.", err=True)
         if exc.paths:
@@ -194,9 +203,16 @@ def create_cmd(vault_root, participant_hex, team_name, niche_name):
 @click.argument("niche_name")
 @click.argument("dest_path")
 def checkout_cmd(vault_root, participant_hex, team_name, niche_name, dest_path):
-    """Add a checkout of a niche at a filesystem path."""
-    vault.add_checkout(vault_root, participant_hex, team_name, niche_name, dest_path)
-    click.echo(f"Checkout added at {dest_path}")
+    """Attach a checkout of a niche at a filesystem path.
+
+    Each niche may have at most one checkout. Remove the existing checkout
+    before attaching a new location.
+    """
+    try:
+        vault.add_checkout(vault_root, participant_hex, team_name, niche_name, dest_path)
+    except vault.DuplicateCheckoutError as exc:
+        _die(str(exc))
+    click.echo(f"Checkout attached at {dest_path}")
 
 
 @cli.command("list")
@@ -210,8 +226,8 @@ def list_cmd(vault_root, participant_hex, team_name):
         click.echo("No niches.")
         return
     for niche in niches:
-        checkouts = vault.list_checkouts(vault_root, participant_hex, team_name, niche["name"])
-        co_str = ", ".join(checkouts) if checkouts else "(no checkouts)"
+        checkout = vault.get_checkout(vault_root, participant_hex, team_name, niche["name"])
+        co_str = checkout if checkout else "(no checkout)"
         click.echo(f"  {niche['name']}  {co_str}  [{niche['id'][:8]}]")
 
 

--- a/packages/shared-file-vault/shared_file_vault/cli.py
+++ b/packages/shared-file-vault/shared_file_vault/cli.py
@@ -126,6 +126,91 @@ def push_cmd(team_name, niche_name, vault_root, participant, hub_port):
     click.echo(f"Pushed niche '{niche_name}' for team '{team_name}'.")
 
 
+@cli.command("fetch")
+@click.argument("team_name")
+@click.argument("niche_name")
+@click.option("--from-member", "from_member", required=True, help="Peer member ID hex")
+@click.option("--vault-root", default=None, help="Override vault root from config")
+@click.option("--participant", default=None, help="Override participant hex from config")
+@click.option("--hub-port", type=int, default=None, help="Override Hub port from config")
+def fetch_cmd(team_name, niche_name, from_member, vault_root, participant, hub_port):
+    """Fetch updates from a peer without merging.
+
+    Parks fetched content locally. No checkout is required. Use this as the
+    first step of the join flow:
+
+      1. fetch --from-member PEER_ID   (no checkout needed)
+      2. checkout ... PATH             (attach a local directory)
+      3. merge --from-member PEER_ID   (integrate fetched content)
+    """
+    vault_root, participant, hub_port = _resolve_sync(vault_root, participant, hub_port)
+    try:
+        vault_root = sync.require_value(vault_root, "vault_root")
+        participant = sync.require_value(participant, "participant_hex")
+        result = sync.fetch_via_hub(
+            vault_root,
+            participant,
+            team_name,
+            niche_name,
+            from_member,
+            hub_port=hub_port,
+        )
+    except (sync.VaultSyncError, OSError) as exc:
+        _die(str(exc))
+
+    if result.niche_sha:
+        click.echo(f"Fetched niche updates from {from_member} ({result.niche_sha[:8]}). Ready to merge.")
+    else:
+        click.echo(f"No new niche updates from {from_member}.")
+
+
+@cli.command("merge")
+@click.argument("team_name")
+@click.argument("niche_name")
+@click.option("--from-member", "from_member", required=True, help="Peer member ID hex")
+@click.option("--vault-root", default=None, help="Override vault root from config")
+@click.option("--participant", default=None, help="Override participant hex from config")
+@click.option("--hub-port", type=int, default=None, help="Override Hub port from config")
+def merge_cmd(team_name, niche_name, from_member, vault_root, participant, hub_port):
+    """Merge previously fetched peer updates into the attached checkout.
+
+    Requires a clean checkout. If the niche has no checkout yet, run
+    'checkout' first to attach one.
+    """
+    vault_root, participant, hub_port = _resolve_sync(vault_root, participant, hub_port)
+    try:
+        vault_root = sync.require_value(vault_root, "vault_root")
+        participant = sync.require_value(participant, "participant_hex")
+        sync.merge_via_hub(
+            vault_root,
+            participant,
+            team_name,
+            niche_name,
+            from_member,
+            hub_port=hub_port,
+        )
+    except sync.DirtyCheckoutError as exc:
+        click.echo("Merge blocked: checkout has uncommitted changes.", err=True)
+        if exc.paths:
+            click.echo("Clean up these files before merging:", err=True)
+            for path in exc.paths:
+                click.echo(f"  {path}", err=True)
+        raise SystemExit(1)
+    except sync.NoCheckoutError as exc:
+        _die(str(exc))
+    except sync.PullConflictError as exc:
+        click.echo(f"Merge left unresolved conflicts in the {exc.scope}.", err=True)
+        if exc.paths:
+            click.echo("Conflicting files:", err=True)
+            for path in exc.paths:
+                click.echo(f"  {path}", err=True)
+        raise SystemExit(1)
+    except (sync.VaultSyncError, OSError) as exc:
+        _die(str(exc))
+
+    click.echo(f"Merged updates from {from_member} into '{niche_name}'.")
+
+
 @cli.command("pull")
 @click.argument("team_name")
 @click.argument("niche_name")
@@ -134,7 +219,10 @@ def push_cmd(team_name, niche_name, vault_root, participant, hub_port):
 @click.option("--participant", default=None, help="Override participant hex from config")
 @click.option("--hub-port", type=int, default=None, help="Override Hub port from config")
 def pull_cmd(team_name, niche_name, from_member, vault_root, participant, hub_port):
-    """Pull a niche and its registry from a peer (fetch + merge)."""
+    """Convenience wrapper for fetch + merge (requires an attached checkout).
+
+    For initial join (no checkout yet), use fetch → checkout → merge instead.
+    """
     vault_root, participant, hub_port = _resolve_sync(vault_root, participant, hub_port)
     try:
         vault_root = sync.require_value(vault_root, "vault_root")

--- a/packages/shared-file-vault/shared_file_vault/cli.py
+++ b/packages/shared-file-vault/shared_file_vault/cli.py
@@ -196,6 +196,8 @@ def merge_cmd(team_name, niche_name, from_member, vault_root, participant, hub_p
             for path in exc.paths:
                 click.echo(f"  {path}", err=True)
         raise SystemExit(1)
+    except sync.StaleCheckoutError as exc:
+        _die(str(exc))
     except sync.NoCheckoutError as exc:
         _die(str(exc))
     except sync.PullConflictError as exc:
@@ -242,6 +244,8 @@ def pull_cmd(team_name, niche_name, from_member, vault_root, participant, hub_po
             for path in exc.paths:
                 click.echo(f"  {path}", err=True)
         raise SystemExit(1)
+    except sync.StaleCheckoutError as exc:
+        _die(str(exc))
     except sync.NoCheckoutError as exc:
         _die(str(exc))
     except sync.PullConflictError as exc:

--- a/packages/shared-file-vault/shared_file_vault/sync.py
+++ b/packages/shared-file-vault/shared_file_vault/sync.py
@@ -54,6 +54,34 @@ class PullConflictError(VaultSyncError):
         super().__init__(f"{scope} merge conflict: {path_text}")
 
 
+class DirtyCheckoutError(VaultSyncError):
+    """Merge rejected because the checkout has uncommitted changes.
+
+    Publish or manually discard all changes (including untracked files)
+    before integrating changes from teammates.
+    """
+
+    def __init__(self, paths: list[str]):
+        self.paths = paths
+        path_text = ", ".join(paths) if paths else "unknown files"
+        super().__init__(f"Checkout is not clean: {path_text}")
+
+
+class NoCheckoutError(VaultSyncError):
+    """Merge rejected because no checkout is attached to this niche.
+
+    Attach a checkout location before merging teammate changes.
+    """
+
+    def __init__(self, team_name: str, niche_name: str):
+        self.team_name = team_name
+        self.niche_name = niche_name
+        super().__init__(
+            f"Niche '{niche_name}' in team '{team_name}' has no local checkout. "
+            "Attach a checkout before merging."
+        )
+
+
 @dataclass
 class FetchResult:
     member_id: str
@@ -440,6 +468,10 @@ def merge_via_hub(
         )
     except vault.MergeConflictError as exc:
         raise PullConflictError("niche", exc.paths) from exc
+    except vault.DirtyCheckoutError as exc:
+        raise DirtyCheckoutError(exc.paths) from exc
+    except vault.NoCheckoutError as exc:
+        raise NoCheckoutError(exc.team_name, exc.niche_name) from exc
 
     return MergeResult(
         member_id=from_member_id,

--- a/packages/shared-file-vault/shared_file_vault/sync.py
+++ b/packages/shared-file-vault/shared_file_vault/sync.py
@@ -446,8 +446,24 @@ def merge_via_hub(
     hub_port: int = SmallSeaClient.DEFAULT_PORT,
     _http_client=None,
 ) -> MergeResult:
-    """Merge already-fetched peer refs for a registry and niche."""
+    """Merge already-fetched peer refs for a registry and niche.
+
+    Preflights the niche checkout before touching the registry, so a
+    dirty-checkout or no-checkout condition never leaves the registry
+    merged while the niche merge is still pending.
+    """
     _session = get_team_session(team_name, hub_port=hub_port, _http_client=_http_client)
+
+    # Preflight: verify niche checkout exists and is clean before merging
+    # anything. Without this, a failed niche merge would leave the registry
+    # already integrated — a partially-merged state the user cannot easily undo.
+    checkout = vault.get_checkout(vault_root, participant_hex, team_name, niche_name)
+    if checkout is None:
+        raise NoCheckoutError(team_name, niche_name)
+    dirty_entries = vault.status(vault_root, participant_hex, team_name, niche_name, checkout)
+    if dirty_entries:
+        raise DirtyCheckoutError([e["path"] for e in dirty_entries])
+
     try:
         registry_sha = vault.merge_registry(
             vault_root,

--- a/packages/shared-file-vault/shared_file_vault/sync.py
+++ b/packages/shared-file-vault/shared_file_vault/sync.py
@@ -82,6 +82,22 @@ class NoCheckoutError(VaultSyncError):
         )
 
 
+class StaleCheckoutError(VaultSyncError):
+    """Merge rejected because the registered checkout directory no longer exists.
+
+    Remove the stale registration and re-attach at the correct path.
+    """
+
+    def __init__(self, team_name: str, niche_name: str, checkout_path: str):
+        self.team_name = team_name
+        self.niche_name = niche_name
+        self.checkout_path = checkout_path
+        super().__init__(
+            f"Registered checkout '{checkout_path}' for niche '{niche_name}' no longer "
+            "exists on disk. Remove the stale registration and re-attach."
+        )
+
+
 @dataclass
 class FetchResult:
     member_id: str
@@ -460,6 +476,8 @@ def merge_via_hub(
     checkout = vault.get_checkout(vault_root, participant_hex, team_name, niche_name)
     if checkout is None:
         raise NoCheckoutError(team_name, niche_name)
+    if not pathlib.Path(checkout).exists():
+        raise StaleCheckoutError(team_name, niche_name, checkout)
     dirty_entries = vault.status(vault_root, participant_hex, team_name, niche_name, checkout)
     if dirty_entries:
         raise DirtyCheckoutError([e["path"] for e in dirty_entries])
@@ -488,6 +506,8 @@ def merge_via_hub(
         raise DirtyCheckoutError(exc.paths) from exc
     except vault.NoCheckoutError as exc:
         raise NoCheckoutError(exc.team_name, exc.niche_name) from exc
+    except vault.StaleCheckoutError as exc:
+        raise StaleCheckoutError(exc.team_name, exc.niche_name, exc.checkout_path) from exc
 
     return MergeResult(
         member_id=from_member_id,

--- a/packages/shared-file-vault/shared_file_vault/templates/fragments/checkouts.html
+++ b/packages/shared-file-vault/shared_file_vault/templates/fragments/checkouts.html
@@ -3,30 +3,25 @@
   <p class="notice notice-err">{{ error }}</p>
   {% endif %}
 
-  {% if checkouts %}
-  <ul style="list-style:none; margin-bottom:0.75rem">
-    {% for co in checkouts %}
-    <li style="display:flex; align-items:center; gap:0.75rem; padding:0.3rem 0; border-bottom:1px solid #f5f5f4">
-      <span class="checkout-path">{{ co }}</span>
-      <form style="margin-left:auto"
-            hx-post="/teams/{{ team_name }}/niches/{{ niche_name }}/checkouts/remove"
-            hx-target="#checkouts-{{ niche_name }}"
-            hx-swap="outerHTML">
-        <input type="hidden" name="checkout_path" value="{{ co }}">
-        <button class="btn btn-danger" type="submit">Remove</button>
-      </form>
-    </li>
-    {% endfor %}
-  </ul>
+  {% if checkout %}
+  <div style="display:flex; align-items:center; gap:0.75rem; padding:0.3rem 0; border-bottom:1px solid #f5f5f4; margin-bottom:0.75rem">
+    <span class="checkout-path">{{ checkout }}</span>
+    <form style="margin-left:auto"
+          hx-post="/teams/{{ team_name }}/niches/{{ niche_name }}/checkouts/remove"
+          hx-target="#checkouts-{{ niche_name }}"
+          hx-swap="outerHTML">
+      <input type="hidden" name="checkout_path" value="{{ checkout }}">
+      <button class="btn btn-danger" type="submit">Remove</button>
+    </form>
+  </div>
   {% else %}
-  <p style="color:#78716c; font-size:0.88rem; margin-bottom:0.75rem">No checkouts registered.</p>
-  {% endif %}
-
+  <p style="color:#78716c; font-size:0.88rem; margin-bottom:0.75rem">No checkout attached.</p>
   <form class="inline-form"
         hx-post="/teams/{{ team_name }}/niches/{{ niche_name }}/checkouts"
         hx-target="#checkouts-{{ niche_name }}"
         hx-swap="outerHTML">
-    <input type="text" name="dest_path" placeholder="Absolute path for new checkout" required>
-    <button class="btn btn-secondary" type="submit">Add checkout</button>
+    <input type="text" name="dest_path" placeholder="Absolute path for checkout" required>
+    <button class="btn btn-secondary" type="submit">Attach checkout</button>
   </form>
+  {% endif %}
 </div>

--- a/packages/shared-file-vault/shared_file_vault/templates/fragments/niche_detail.html
+++ b/packages/shared-file-vault/shared_file_vault/templates/fragments/niche_detail.html
@@ -4,7 +4,7 @@
 </div>
 
 <div class="detail-section">
-  <h3>Checkouts</h3>
+  <h3>Checkout</h3>
   {% include "fragments/checkouts.html" %}
 </div>
 
@@ -31,6 +31,15 @@
       {% for peer in peers %}
       <div style="border:1px solid #d6d3d1; border-radius:0.75rem; padding:0.75rem; min-width:15rem">
         <div style="font-weight:600; margin-bottom:0.5rem">{{ peer.label }}</div>
+        {% if peer.update_status.ready_to_merge and peer.update_status.parked_sha %}
+        <p class="notice notice-ok" style="margin-bottom:0.5rem; font-size:0.88rem">
+          Changes from this teammate are available ({{ peer.update_status.parked_sha[:8] }}).
+        </p>
+        {% elif peer.update_status.already_merged and peer.update_status.parked_sha %}
+        <p style="color:#57534e; font-size:0.88rem; margin-bottom:0.5rem">
+          Latest fetched ({{ peer.update_status.parked_sha[:8] }}) is already merged.
+        </p>
+        {% endif %}
         <div style="display:flex; gap:0.5rem; flex-wrap:wrap">
           <form hx-post="/teams/{{ team_name }}/niches/{{ niche_name }}/fetch"
                 hx-target="#niche-detail"
@@ -51,15 +60,6 @@
           </form>
           {% endif %}
         </div>
-        {% if peer.update_status.ready_to_merge and peer.update_status.parked_sha %}
-        <p style="color:#57534e; font-size:0.88rem; margin:0.5rem 0 0">
-          Fetched {{ peer.update_status.parked_sha[:8] }} and ready to merge.
-        </p>
-        {% elif peer.update_status.already_merged and peer.update_status.parked_sha %}
-        <p style="color:#57534e; font-size:0.88rem; margin:0.5rem 0 0">
-          Latest fetched {{ peer.update_status.parked_sha[:8] }} is already merged.
-        </p>
-        {% endif %}
       </div>
       {% endfor %}
     </div>
@@ -74,20 +74,17 @@
   </p>
 </div>
 
-{% if status_by_checkout %}
-  {% for item in status_by_checkout %}
-  <div class="detail-section">
-    <h3>Status — <span class="checkout-path">{{ item.path }}</span></h3>
-    {# set variables for status_panel.html include #}
-    {% set checkout_path = item.path %}
-    {% set entries = item.entries %}
-    {% set commits = [] %}
-    {% include "fragments/status_panel.html" %}
-  </div>
-  {% endfor %}
+{% if checkout %}
+<div class="detail-section">
+  <h3>Status — <span class="checkout-path">{{ checkout }}</span></h3>
+  {% set checkout_path = checkout %}
+  {% set entries = checkout_status %}
+  {% set commits = [] %}
+  {% include "fragments/status_panel.html" %}
+</div>
 {% else %}
 <div class="detail-section">
-  <p style="color:#78716c; font-size:0.88rem">Add a checkout above to see status and publish changes.</p>
+  <p style="color:#78716c; font-size:0.88rem">Attach a checkout above to see status and publish changes.</p>
 </div>
 {% endif %}
 

--- a/packages/shared-file-vault/shared_file_vault/templates/fragments/team_section.html
+++ b/packages/shared-file-vault/shared_file_vault/templates/fragments/team_section.html
@@ -5,7 +5,7 @@
     <thead>
       <tr>
         <th>Niche</th>
-        <th>Checkouts</th>
+        <th>Checkout</th>
         <th></th>
       </tr>
     </thead>
@@ -20,10 +20,10 @@
                   hx-push-url="false">{{ niche.name }}</button>
         </td>
         <td>
-          {% if niche.checkout_count == 0 %}
-            <span class="badge badge-none">no checkouts</span>
+          {% if niche.has_checkout %}
+            <span class="badge badge-clean">attached</span>
           {% else %}
-            <span class="badge badge-clean">{{ niche.checkout_count }} checkout{% if niche.checkout_count != 1 %}s{% endif %}</span>
+            <span class="badge badge-none">none</span>
           {% endif %}
         </td>
         <td style="text-align:right; white-space:nowrap">

--- a/packages/shared-file-vault/shared_file_vault/vault.py
+++ b/packages/shared-file-vault/shared_file_vault/vault.py
@@ -342,6 +342,10 @@ def _refresh_work_tree(git_dir, dest):
 def _is_checkout_clean(checkout_path, git_dir):
     """Return True if the checkout has no tracked or untracked changes.
 
+    Returns False — rather than raising — if the checkout directory does not
+    exist on disk or if git exits non-zero for any reason. This prevents a
+    missing or unreadable checkout from being mistaken for a clean one.
+
     Uses 'git status --porcelain' which reports both tracked modifications
     and untracked files. Untracked files block merge operations just as
     tracked changes do — this is intentional: non-git users should not need
@@ -352,6 +356,8 @@ def _is_checkout_clean(checkout_path, git_dir):
     work tree (transit always resets itself to HEAD before use, so checking
     it would silently pass even when the user's checkout is dirty).
     """
+    if not pathlib.Path(checkout_path).exists():
+        return False
     result = gitCmd(
         [
             "--git-dir", str(git_dir), "--work-tree", str(checkout_path),
@@ -359,7 +365,7 @@ def _is_checkout_clean(checkout_path, git_dir):
         ],
         raise_on_error=False,
     )
-    return result.stdout.strip() == ""
+    return result.returncode == 0 and result.stdout.strip() == ""
 
 
 def _conflict_paths(git_dir, work_tree):
@@ -759,14 +765,38 @@ def list_teams(vault_root, participant_hex):
     ]
 
 
+def _require_clean_checkout(vault_root, participant_hex, team_name, niche_name):
+    """Verify a checkout is attached, exists on disk, and is clean.
+
+    Returns the checkout path. Raises NoCheckoutError, ValueError (missing
+    path), or DirtyCheckoutError as appropriate. Called by pull_niche and
+    merge_niche before any transit operations so that transit's always-clean
+    state is never mistakenly used as the check target.
+    """
+    git_dir = _niche_git_dir(vault_root, participant_hex, team_name, niche_name)
+    checkout = get_checkout(vault_root, participant_hex, team_name, niche_name)
+    if checkout is None:
+        raise NoCheckoutError(team_name, niche_name)
+    if not pathlib.Path(checkout).exists():
+        raise ValueError(
+            f"Registered checkout '{checkout}' no longer exists on disk. "
+            "Remove the registration and re-attach at the correct path."
+        )
+    if not _is_checkout_clean(checkout, git_dir):
+        dirty = [e["path"] for e in status(vault_root, participant_hex, team_name, niche_name, checkout)]
+        raise DirtyCheckoutError(dirty)
+    return checkout
+
+
 def pull_niche(vault_root, participant_hex, team_name, niche_name, remote):
     """Pull a niche from cloud storage and merge.
 
-    Creates the niche git repo if this is the first time pulling it
-    (e.g. a new team member joining). If a checkout is attached, requires
-    it to be clean before proceeding and refreshes it after a successful merge.
-    If no checkout is attached, performs the merge in the transit work tree
-    only; no visible files are written.
+    Requires a checkout to be attached and clean. This keeps pull semantics
+    consistent with merge: visible files are only updated through an explicit
+    action, never automatically on a subsequent add_checkout call.
+
+    For the initial join flow (no checkout yet), use fetch_niche to park the
+    remote content, then add_checkout, then merge_niche.
     """
     git_dir = _niche_git_dir(vault_root, participant_hex, team_name, niche_name)
     if not git_dir.exists():
@@ -777,18 +807,10 @@ def pull_niche(vault_root, participant_hex, team_name, niche_name, remote):
     if not transit.exists():
         _make_work_tree(git_dir, transit)
 
-    # Guard: if a checkout is attached, it must be clean before we merge.
-    # The guard targets the user's checkout, not transit (transit resets
-    # itself to HEAD before every merge and would always appear clean).
-    checkout = get_checkout(vault_root, participant_hex, team_name, niche_name)
-    if checkout is not None and not _is_checkout_clean(checkout, git_dir):
-        dirty = [e["path"] for e in status(vault_root, participant_hex, team_name, niche_name, checkout)]
-        raise DirtyCheckoutError(dirty)
+    checkout = _require_clean_checkout(vault_root, participant_hex, team_name, niche_name)
 
     _cod_pull(git_dir, transit, remote)
-
-    if checkout is not None:
-        _refresh_work_tree(git_dir, checkout)
+    _refresh_work_tree(git_dir, checkout)
 
 
 def fetch_niche(vault_root, participant_hex, team_name, niche_name, member_id, remote):
@@ -826,13 +848,7 @@ def merge_niche(vault_root, participant_hex, team_name, niche_name, member_id):
     git_dir = _niche_git_dir(vault_root, participant_hex, team_name, niche_name)
     transit = _niche_transit_dir(vault_root, participant_hex, team_name, niche_name)
 
-    # Guard: require a checkout and verify it is clean before touching transit.
-    checkout = get_checkout(vault_root, participant_hex, team_name, niche_name)
-    if checkout is None:
-        raise NoCheckoutError(team_name, niche_name)
-    if not _is_checkout_clean(checkout, git_dir):
-        dirty = [e["path"] for e in status(vault_root, participant_hex, team_name, niche_name, checkout)]
-        raise DirtyCheckoutError(dirty)
+    checkout = _require_clean_checkout(vault_root, participant_hex, team_name, niche_name)
 
     ref_name = _peer_ref_name(member_id)
     parked_sha = _resolve_ref(git_dir, transit, ref_name)

--- a/packages/shared-file-vault/shared_file_vault/vault.py
+++ b/packages/shared-file-vault/shared_file_vault/vault.py
@@ -84,6 +84,25 @@ class NoCheckoutError(RuntimeError):
         )
 
 
+class StaleCheckoutError(RuntimeError):
+    """Raised when the registered checkout directory no longer exists on disk.
+
+    The checkout registration is still in the database, but the directory it
+    points to has been moved or deleted. Remove the stale registration and
+    re-attach at the correct path.
+    """
+
+    def __init__(self, team_name, niche_name, checkout_path):
+        self.team_name = team_name
+        self.niche_name = niche_name
+        self.checkout_path = checkout_path
+        super().__init__(
+            f"Registered checkout '{checkout_path}' for niche '{niche_name}' in team "
+            f"'{team_name}' no longer exists on disk. "
+            "Remove the stale registration and re-attach at the correct path."
+        )
+
+
 def uuid7():
     """Generate a UUIDv7 (time-ordered, random) as 16 bytes."""
     timestamp_ms = int(time.time() * 1000)
@@ -778,10 +797,7 @@ def _require_clean_checkout(vault_root, participant_hex, team_name, niche_name):
     if checkout is None:
         raise NoCheckoutError(team_name, niche_name)
     if not pathlib.Path(checkout).exists():
-        raise ValueError(
-            f"Registered checkout '{checkout}' no longer exists on disk. "
-            "Remove the registration and re-attach at the correct path."
-        )
+        raise StaleCheckoutError(team_name, niche_name, checkout)
     if not _is_checkout_clean(checkout, git_dir):
         dirty = [e["path"] for e in status(vault_root, participant_hex, team_name, niche_name, checkout)]
         raise DirtyCheckoutError(dirty)

--- a/packages/shared-file-vault/shared_file_vault/vault.py
+++ b/packages/shared-file-vault/shared_file_vault/vault.py
@@ -5,9 +5,8 @@ See spec.md for the design. Key points:
 - One vault per device/participant. vault_root + participant_hex identify it.
 - Niches are shared file trees backed by git repos, synced via Cod Sync.
 - The niche registry (which niches exist per team) is itself a git repo
-  synced via its own Cod Sync chain. It stores one YAML file per niche.
-- Checkouts are purely local: multiple checkouts of the same niche are
-  allowed; they are tracked in a local checkouts.db.
+  synced via its own Cod Sync chain. It stores one JSON file per niche.
+- Each niche has at most one local checkout per device, tracked in checkouts.db.
 - Bundle temp files always live inside the niche/registry git dir so they
   never appear in user-visible checkout directories.
 """
@@ -33,6 +32,56 @@ class MergeConflictError(RuntimeError):
     def __init__(self, paths):
         self.paths = paths
         super().__init__("Merge conflict during pull")
+
+
+class DuplicateCheckoutError(ValueError):
+    """Raised when trying to add a checkout for a niche that already has one.
+
+    Remove the existing checkout before attaching a new location.
+    """
+
+    def __init__(self, team_name, niche_name, existing_path):
+        self.team_name = team_name
+        self.niche_name = niche_name
+        self.existing_path = existing_path
+        super().__init__(
+            f"Niche '{niche_name}' in team '{team_name}' already has a checkout at "
+            f"'{existing_path}'. Remove it before attaching a new one."
+        )
+
+
+class DirtyCheckoutError(RuntimeError):
+    """Raised when a merge operation finds uncommitted changes in the user's checkout.
+
+    Both tracked modifications and untracked files are treated as dirty.
+    The checkout must be fully clean before integrating changes from teammates.
+    This is intentional: non-git users should not need to understand the
+    tracked/untracked distinction, and hiding untracked files could mask
+    path-collision cases during merge.
+    """
+
+    def __init__(self, paths):
+        self.paths = paths
+        super().__init__(
+            "Checkout has uncommitted changes. Publish or discard them before merging.\n"
+            + "".join(f"  {p}\n" for p in paths)
+        )
+
+
+class NoCheckoutError(RuntimeError):
+    """Raised when a merge operation is attempted but no checkout is attached.
+
+    Fetch can still run without a checkout. Merge requires a checkout to
+    exist so that fetched changes can be written to a visible location.
+    """
+
+    def __init__(self, team_name, niche_name):
+        self.team_name = team_name
+        self.niche_name = niche_name
+        super().__init__(
+            f"Niche '{niche_name}' in team '{team_name}' has no local checkout. "
+            "Attach a checkout before merging."
+        )
 
 
 def uuid7():
@@ -102,13 +151,19 @@ def _bundle_tmp_dir(git_dir):
 # SQLite helpers
 # ---------------------------------------------------------------------------
 
+_CHECKOUTS_DB_VERSION = 1
+
 _CHECKOUTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+);
 CREATE TABLE IF NOT EXISTS checkout (
     id            BLOB PRIMARY KEY,
     team_name     TEXT NOT NULL,
     niche_name    TEXT NOT NULL,
     checkout_path TEXT NOT NULL,
-    created_at    TEXT NOT NULL
+    created_at    TEXT NOT NULL,
+    UNIQUE (team_name, niche_name)
 );
 CREATE TABLE IF NOT EXISTS peer_sync (
     team_name        TEXT NOT NULL,
@@ -127,7 +182,29 @@ def _connect_checkouts(vault_root, participant_hex):
     db = _checkouts_db_path(vault_root, participant_hex)
     conn = sqlite3.connect(str(db))
     conn.row_factory = sqlite3.Row
+
+    # Check schema version; recreate the DB if stale. checkouts.db is
+    # device-local and reconstructable, so recreation is safe.
+    try:
+        row = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+        version = row[0] if row else None
+    except sqlite3.OperationalError:
+        version = None
+
+    if version != _CHECKOUTS_DB_VERSION:
+        conn.close()
+        db.unlink(missing_ok=True)
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+
     conn.executescript(_CHECKOUTS_SCHEMA)
+
+    if not conn.execute("SELECT 1 FROM schema_version LIMIT 1").fetchone():
+        conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?)", (_CHECKOUTS_DB_VERSION,)
+        )
+        conn.commit()
+
     return conn
 
 
@@ -260,6 +337,29 @@ def _refresh_work_tree(git_dir, dest):
         "--git-dir", str(git_dir), "--work-tree", str(dest),
         "checkout", "HEAD", "--", ".",
     ])
+
+
+def _is_checkout_clean(checkout_path, git_dir):
+    """Return True if the checkout has no tracked or untracked changes.
+
+    Uses 'git status --porcelain' which reports both tracked modifications
+    and untracked files. Untracked files block merge operations just as
+    tracked changes do — this is intentional: non-git users should not need
+    to understand the tracked/untracked distinction, and hiding untracked
+    files from the check could mask path-collision cases during merge.
+
+    Always called with the user's checkout_path, never with the transit
+    work tree (transit always resets itself to HEAD before use, so checking
+    it would silently pass even when the user's checkout is dirty).
+    """
+    result = gitCmd(
+        [
+            "--git-dir", str(git_dir), "--work-tree", str(checkout_path),
+            "status", "--porcelain",
+        ],
+        raise_on_error=False,
+    )
+    return result.stdout.strip() == ""
 
 
 def _conflict_paths(git_dir, work_tree):
@@ -409,8 +509,7 @@ def init_vault(vault_root, participant_hex):
     """Create the vault directory and local checkout registry database."""
     pdir = _participant_dir(vault_root, participant_hex)
     pdir.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(_checkouts_db_path(vault_root, participant_hex)))
-    conn.executescript(_CHECKOUTS_SCHEMA)
+    conn = _connect_checkouts(vault_root, participant_hex)
     conn.close()
 
 
@@ -478,14 +577,21 @@ def list_niches(vault_root, participant_hex, team_name):
 
 
 def add_checkout(vault_root, participant_hex, team_name, niche_name, dest_path):
-    """Register a local directory as a checkout of a niche.
+    """Register a local directory as the checkout of a niche.
 
-    Multiple checkouts of the same niche are allowed.
+    Each niche may have at most one checkout on a device. Raises
+    DuplicateCheckoutError if one is already registered. Remove the existing
+    checkout before attaching a new location.
+
     If the niche already has commits, dest_path is populated immediately.
     """
     git_dir = _niche_git_dir(vault_root, participant_hex, team_name, niche_name)
     if not git_dir.exists():
         raise ValueError(f"Niche '{niche_name}' does not exist in team '{team_name}'")
+
+    existing = get_checkout(vault_root, participant_hex, team_name, niche_name)
+    if existing is not None:
+        raise DuplicateCheckoutError(team_name, niche_name, existing)
 
     _make_work_tree(git_dir, dest_path)
 
@@ -516,24 +622,26 @@ def remove_checkout(vault_root, participant_hex, team_name, niche_name, checkout
     conn.close()
 
 
-def list_checkouts(vault_root, participant_hex, team_name, niche_name):
-    """Return list of checkout paths registered for a niche."""
+def get_checkout(vault_root, participant_hex, team_name, niche_name):
+    """Return the single registered checkout path for a niche, or None."""
     conn = _connect_checkouts(vault_root, participant_hex)
-    rows = conn.execute(
+    row = conn.execute(
         "SELECT checkout_path FROM checkout WHERE team_name = ? AND niche_name = ?",
         (team_name, niche_name),
-    ).fetchall()
+    ).fetchone()
     conn.close()
-    return [row["checkout_path"] for row in rows]
+    return row["checkout_path"] if row else None
+
+
+def list_checkouts(vault_root, participant_hex, team_name, niche_name):
+    """Return list of checkout paths for a niche (at most one element)."""
+    checkout = get_checkout(vault_root, participant_hex, team_name, niche_name)
+    return [checkout] if checkout is not None else []
 
 
 def publish(vault_root, participant_hex, team_name, niche_name, checkout_path,
             files=None, message=None):
-    """Stage changes in a checkout and commit. Returns commit hash.
-
-    After committing, refreshes all other registered checkouts of this
-    niche so they reflect the new HEAD.
-    """
+    """Stage changes in a checkout and commit. Returns commit hash."""
     git_dir = _niche_git_dir(vault_root, participant_hex, team_name, niche_name)
     checkout = pathlib.Path(checkout_path).resolve()
     git_prefix = ["--git-dir", str(git_dir), "--work-tree", str(checkout)]
@@ -547,14 +655,7 @@ def publish(vault_root, participant_hex, team_name, niche_name, checkout_path,
     gitCmd(git_prefix + ["commit", "-m", message or "Published changes"])
 
     result = gitCmd(git_prefix + ["rev-parse", "HEAD"])
-    head = result.stdout.strip()
-
-    # Refresh sibling checkouts
-    for other in list_checkouts(vault_root, participant_hex, team_name, niche_name):
-        if pathlib.Path(other).resolve() != checkout:
-            _refresh_work_tree(git_dir, other)
-
-    return head
+    return result.stdout.strip()
 
 
 def status(vault_root, participant_hex, team_name, niche_name, checkout_path):
@@ -662,8 +763,10 @@ def pull_niche(vault_root, participant_hex, team_name, niche_name, remote):
     """Pull a niche from cloud storage and merge.
 
     Creates the niche git repo if this is the first time pulling it
-    (e.g. a new team member joining). Updates all registered checkouts
-    after a successful merge.
+    (e.g. a new team member joining). If a checkout is attached, requires
+    it to be clean before proceeding and refreshes it after a successful merge.
+    If no checkout is attached, performs the merge in the transit work tree
+    only; no visible files are written.
     """
     git_dir = _niche_git_dir(vault_root, participant_hex, team_name, niche_name)
     if not git_dir.exists():
@@ -674,15 +777,26 @@ def pull_niche(vault_root, participant_hex, team_name, niche_name, remote):
     if not transit.exists():
         _make_work_tree(git_dir, transit)
 
+    # Guard: if a checkout is attached, it must be clean before we merge.
+    # The guard targets the user's checkout, not transit (transit resets
+    # itself to HEAD before every merge and would always appear clean).
+    checkout = get_checkout(vault_root, participant_hex, team_name, niche_name)
+    if checkout is not None and not _is_checkout_clean(checkout, git_dir):
+        dirty = [e["path"] for e in status(vault_root, participant_hex, team_name, niche_name, checkout)]
+        raise DirtyCheckoutError(dirty)
+
     _cod_pull(git_dir, transit, remote)
 
-    # Refresh all user checkouts
-    for checkout in list_checkouts(vault_root, participant_hex, team_name, niche_name):
+    if checkout is not None:
         _refresh_work_tree(git_dir, checkout)
 
 
 def fetch_niche(vault_root, participant_hex, team_name, niche_name, member_id, remote):
-    """Fetch a niche from a peer and pin it to a durable local ref."""
+    """Fetch a niche from a peer and pin it to a durable local ref.
+
+    Fetch does not modify the user's checkout, so no clean-checkout guard
+    is needed here. The guard fires at merge time.
+    """
     git_dir = _niche_git_dir(vault_root, participant_hex, team_name, niche_name)
     if not git_dir.exists():
         git_dir.mkdir(parents=True)
@@ -702,9 +816,24 @@ def fetch_niche(vault_root, participant_hex, team_name, niche_name, member_id, r
 
 
 def merge_niche(vault_root, participant_hex, team_name, niche_name, member_id):
-    """Merge a previously parked niche ref from a peer."""
+    """Merge a previously parked niche ref from a peer.
+
+    Requires a checkout to be attached (raises NoCheckoutError if none).
+    Requires the checkout to be clean (raises DirtyCheckoutError if not).
+    The clean-checkout guard fires here, before any transit operations,
+    because transit always resets to HEAD and would silently pass the check.
+    """
     git_dir = _niche_git_dir(vault_root, participant_hex, team_name, niche_name)
     transit = _niche_transit_dir(vault_root, participant_hex, team_name, niche_name)
+
+    # Guard: require a checkout and verify it is clean before touching transit.
+    checkout = get_checkout(vault_root, participant_hex, team_name, niche_name)
+    if checkout is None:
+        raise NoCheckoutError(team_name, niche_name)
+    if not _is_checkout_clean(checkout, git_dir):
+        dirty = [e["path"] for e in status(vault_root, participant_hex, team_name, niche_name, checkout)]
+        raise DirtyCheckoutError(dirty)
+
     ref_name = _peer_ref_name(member_id)
     parked_sha = _resolve_ref(git_dir, transit, ref_name)
     if parked_sha is None:
@@ -719,8 +848,7 @@ def merge_niche(vault_root, participant_hex, team_name, niche_name, member_id):
         vault_root, participant_hex, team_name, "niche", niche_name, member_id, parked_sha
     )
 
-    for checkout in list_checkouts(vault_root, participant_hex, team_name, niche_name):
-        _refresh_work_tree(git_dir, checkout)
+    _refresh_work_tree(git_dir, checkout)
     return parked_sha
 
 

--- a/packages/shared-file-vault/shared_file_vault/web.py
+++ b/packages/shared-file-vault/shared_file_vault/web.py
@@ -416,6 +416,12 @@ def create_app(
                 f"Merge blocked: checkout has uncommitted changes ({path_list}). "
                 "Publish or discard them before merging."
             )
+        except sync.StaleCheckoutError as exc:
+            notice = None
+            error = (
+                f"Merge blocked: registered checkout '{exc.checkout_path}' no longer exists. "
+                "Remove the stale registration and re-attach at the correct path."
+            )
         except sync.NoCheckoutError:
             notice = None
             error = "Merge blocked: no checkout is attached. Attach a checkout location first."

--- a/packages/shared-file-vault/shared_file_vault/web.py
+++ b/packages/shared-file-vault/shared_file_vault/web.py
@@ -97,11 +97,12 @@ def create_app(
                 peers = []
         else:
             peers = []
-        checkouts = vault.list_checkouts(vr, ph, team_name, niche_name)
-        status_by_checkout = [
-            {"path": co, "entries": vault.status(vr, ph, team_name, niche_name, co)}
-            for co in checkouts
-        ]
+        checkout = vault.get_checkout(vr, ph, team_name, niche_name)
+        checkout_status = (
+            vault.status(vr, ph, team_name, niche_name, checkout)
+            if checkout is not None
+            else []
+        )
         commits = vault.log(vr, ph, team_name, niche_name)
         return templates.TemplateResponse(
             "fragments/niche_detail.html",
@@ -109,8 +110,8 @@ def create_app(
                 "request": request,
                 "team_name": team_name,
                 "niche_name": niche_name,
-                "checkouts": checkouts,
-                "status_by_checkout": status_by_checkout,
+                "checkout": checkout,
+                "checkout_status": checkout_status,
                 "commits": commits,
                 "sync_notice": sync_notice,
                 "sync_error": sync_error,
@@ -233,16 +234,16 @@ def create_app(
         try:
             vault.add_checkout(vr, ph, team_name, niche_name, dest_path)
             error = None
-        except ValueError as e:
+        except (ValueError, vault.DuplicateCheckoutError) as e:
             error = str(e)
-        checkouts = vault.list_checkouts(vr, ph, team_name, niche_name)
+        checkout = vault.get_checkout(vr, ph, team_name, niche_name)
         return templates.TemplateResponse(
             "fragments/checkouts.html",
             {
                 "request": request,
                 "team_name": team_name,
                 "niche_name": niche_name,
-                "checkouts": checkouts,
+                "checkout": checkout,
                 "error": error,
             },
         )
@@ -259,14 +260,14 @@ def create_app(
     ):
         vr, ph = _vr(request), _ph(request)
         vault.remove_checkout(vr, ph, team_name, niche_name, checkout_path)
-        checkouts = vault.list_checkouts(vr, ph, team_name, niche_name)
+        checkout = vault.get_checkout(vr, ph, team_name, niche_name)
         return templates.TemplateResponse(
             "fragments/checkouts.html",
             {
                 "request": request,
                 "team_name": team_name,
                 "niche_name": niche_name,
-                "checkouts": checkouts,
+                "checkout": checkout,
                 "error": None,
             },
         )
@@ -408,6 +409,16 @@ def create_app(
             )
             notice = f"Merged parked changes from {member_id}."
             error = None
+        except sync.DirtyCheckoutError as exc:
+            notice = None
+            path_list = ", ".join(exc.paths) if exc.paths else "unknown files"
+            error = (
+                f"Merge blocked: checkout has uncommitted changes ({path_list}). "
+                "Publish or discard them before merging."
+            )
+        except sync.NoCheckoutError:
+            notice = None
+            error = "Merge blocked: no checkout is attached. Attach a checkout location first."
         except sync.PullConflictError as exc:
             notice = None
             if exc.paths:
@@ -433,12 +444,10 @@ def create_app(
 
 
 def _niches_with_info(vault_root, participant_hex, team_name):
-    """Return niches annotated with local checkout count."""
+    """Return niches annotated with whether a checkout is attached."""
     niches = vault.list_niches(vault_root, participant_hex, team_name)
     result = []
     for n in niches:
-        checkouts = vault.list_checkouts(
-            vault_root, participant_hex, team_name, n["name"]
-        )
-        result.append({**n, "checkout_count": len(checkouts)})
+        checkout = vault.get_checkout(vault_root, participant_hex, team_name, n["name"])
+        result.append({**n, "has_checkout": checkout is not None})
     return result

--- a/packages/shared-file-vault/spec.md
+++ b/packages/shared-file-vault/spec.md
@@ -41,10 +41,18 @@ filesystem where the user actually reads and writes files. The git metadata
 lives inside the vault (via `--separate-git-dir`); the checkout directory
 contains only the user's files.
 
-Checkouts are **purely local state** — they are not shared with teammates
-and do not need to sync via NoteToSelf. There is no limit on how many
-checkouts a niche can have, and checkout paths may overlap in arbitrary
-ways (since the git dir lives elsewhere, there is no technical constraint).
+Checkouts are **purely local state** — they are not shared with teammates.
+**Each niche has at most one checkout on a given device.** A niche is either
+not materialized locally (no checkout), or it is materialized at exactly one
+path. To move a checkout to a different path, remove the existing one and
+attach a new one.
+
+**Merge operations require a clean checkout.** Before integrating changes
+from a teammate (`merge_niche`, `pull_niche` when a checkout is attached),
+the checkout must have no uncommitted tracked changes and no untracked files.
+The user must publish or discard all local changes first. Untracked files are
+treated the same as tracked changes — the rule is simply "the folder must be
+clean", with no tracked/untracked distinction exposed to the user.
 
 ### Vault
 
@@ -102,17 +110,22 @@ macOS, `%APPDATA%\SmallSea\FileVault` on Windows).
 ### checkouts.db schema
 
 ```sql
+CREATE TABLE schema_version (
+    version INTEGER NOT NULL
+);
 CREATE TABLE checkout (
     id            BLOB PRIMARY KEY,   -- UUIDv7
     team_name     TEXT NOT NULL,
     niche_name    TEXT NOT NULL,
     checkout_path TEXT NOT NULL,
-    created_at    TEXT NOT NULL
+    created_at    TEXT NOT NULL,
+    UNIQUE (team_name, niche_name)    -- at most one checkout per niche
 );
 ```
 
-Multiple rows with the same `(team_name, niche_name)` are allowed —
-one per checkout of that niche.
+The `schema_version` table holds a single row. On version mismatch the
+entire database is recreated from scratch (it is device-local and
+reconstructable). No migration SQL is written.
 
 ---
 
@@ -129,9 +142,9 @@ one per checkout of that niche.
 
 | Operation | Description |
 |-----------|-------------|
-| `add_checkout` | Register a local directory as a checkout of a niche. Creates the git work tree link. |
-| `remove_checkout` | Unregister a checkout (does not delete the files). |
-| `list_checkouts` | List all checkouts for a niche. |
+| `add_checkout` | Attach the single checkout of a niche to a local directory. Raises `DuplicateCheckoutError` if one already exists. |
+| `remove_checkout` | Detach the checkout (does not delete files). |
+| `get_checkout` | Return the checkout path or `None`. |
 
 ### Day-to-day
 
@@ -145,8 +158,10 @@ one per checkout of that niche.
 
 | Operation | Description |
 |-----------|-------------|
-| `push_niche` | Push a niche (or the registry) to a cloud remote via Cod Sync. |
-| `pull_niche` | Fetch from a cloud remote and merge into the local niche repo. Updates all checkouts. |
+| `push_niche` | Push a niche to a cloud remote via Cod Sync. |
+| `pull_niche` | Fetch from a cloud remote and merge into the local niche repo. Requires a clean checkout if one is attached; refreshes it after merge. |
+| `fetch_niche` | Fetch from a peer and park the ref locally without merging. No checkout required. |
+| `merge_niche` | Merge a previously parked peer ref. Requires a clean attached checkout. |
 | `push_registry` | Push the niche registry to a cloud remote. |
 | `pull_registry` | Pull the niche registry from a cloud remote and merge. |
 

--- a/packages/shared-file-vault/tests/test_aspirational.py
+++ b/packages/shared-file-vault/tests/test_aspirational.py
@@ -26,9 +26,11 @@ from cod_sync.protocol import LocalFolderRemote
 from shared_file_vault.vault import (
     add_checkout,
     create_niche,
+    fetch_niche,
     get_checkout,
     init_vault,
     list_niches,
+    merge_niche,
     publish,
     pull_niche,
     pull_registry,
@@ -103,11 +105,15 @@ def test_registry_propagation(playground_dir):
     niche_names = [n["name"] for n in niches]
     assert "docs" in niche_names, "Bob should discover the 'docs' niche via the registry"
 
-    # Bob pulls the niche content and adds his own checkout
-    pull_niche(str(bob_root), BOB, TEAM, "docs", LocalFolderRemote(str(alice_niche_cloud)))
+    # Bob joins the niche: fetch → attach checkout → merge (3-step join flow).
+    # Fetch parks Alice's content under a peer ref without advancing HEAD.
+    # add_checkout then creates an empty checkout. merge_niche integrates the
+    # parked ref and refreshes the checkout with Alice's files.
+    fetch_niche(str(bob_root), BOB, TEAM, "docs", ALICE, LocalFolderRemote(str(alice_niche_cloud)))
 
     bob_co = playground / "checkout-bob-docs"
     add_checkout(str(bob_root), BOB, TEAM, "docs", str(bob_co))
+    merge_niche(str(bob_root), BOB, TEAM, "docs", ALICE)
 
     assert exists(bob_co, "readme.txt"), "Bob's checkout should contain Alice's file"
     assert read(bob_co, "readme.txt") == "Hello from Alice.\n"
@@ -235,10 +241,12 @@ def test_full_join_flow(playground_dir):
     discovered = [n["name"] for n in list_niches(str(bob_root), BOB, TEAM)]
     assert "docs" in discovered
 
-    pull_niche(str(bob_root), BOB, TEAM, "docs", LocalFolderRemote(str(alice_niche_cloud)))
+    # 3-step join flow: fetch → attach checkout → merge
+    fetch_niche(str(bob_root), BOB, TEAM, "docs", ALICE, LocalFolderRemote(str(alice_niche_cloud)))
 
     bob_co = playground / "checkout-bob"
     add_checkout(str(bob_root), BOB, TEAM, "docs", str(bob_co))
+    merge_niche(str(bob_root), BOB, TEAM, "docs", ALICE)
 
     assert exists(bob_co, "guide.txt")
     assert read(bob_co, "guide.txt") == "Getting started.\n"

--- a/packages/shared-file-vault/tests/test_aspirational.py
+++ b/packages/shared-file-vault/tests/test_aspirational.py
@@ -1,9 +1,8 @@
 """
-Aspirational tests for the redesigned Shared File Vault.
+Scenario tests for the Shared File Vault.
 
-These tests are written against the spec (spec.md) and will fail until
-the implementation catches up. They cover the four tricky cases that
-diverge most from the current implementation:
+These cover the multi-participant workflows that exercise the most
+important end-to-end behavior:
 
   1. Registry propagation — Bob discovers a niche via the shared registry
      without Alice telling him its name out-of-band.
@@ -11,33 +10,12 @@ diverge most from the current implementation:
   2. Concurrent registry additions — Alice and Bob each create a niche
      independently; after cross-pulling registries both see all niches.
 
-  3. Multiple checkouts — one niche, two checkout paths on the same device;
-     both reflect committed state.
-
-  4. Full join flow — Bob starts with an empty vault, pulls the registry,
+  3. Full join flow — Bob starts with an empty vault, pulls the registry,
      discovers a niche, pulls the niche content, adds a checkout, reads
-     Alice's files.
+     Alice's files and contributes back.
 
-API assumed by these tests (post-spec):
-
-  init_vault(vault_root, participant_hex)
-  create_niche(vault_root, participant_hex, team_name, niche_name)
-  list_niches(vault_root, participant_hex, team_name) -> [{name, ...}]
-  add_checkout(vault_root, participant_hex, team_name, niche_name, dest_path)
-  remove_checkout(vault_root, participant_hex, team_name, niche_name, checkout_path)
-  list_checkouts(vault_root, participant_hex, team_name, niche_name) -> [str]
-  publish(vault_root, participant_hex, team_name, niche_name, checkout_path, message=None)
-  status(vault_root, participant_hex, team_name, niche_name, checkout_path)
-  push_niche(vault_root, participant_hex, team_name, niche_name, cloud_dir)
-  pull_niche(vault_root, participant_hex, team_name, niche_name, cloud_dir)
-  push_registry(vault_root, participant_hex, team_name, cloud_dir)
-  pull_registry(vault_root, participant_hex, team_name, cloud_dir)
-
-Key differences from current implementation:
-- checkout_path is explicit in publish/status (multiple checkouts allowed)
-- add_checkout replaces checkout_niche (no one-per-niche constraint)
-- push_registry / pull_registry sync the shared niche registry
-- list_niches reads from the shared registry, not a local-only DB
+Note: each niche has at most one checkout per device. Add/remove is the
+supported workflow for relocating a checkout.
 """
 
 import pathlib
@@ -48,8 +26,8 @@ from cod_sync.protocol import LocalFolderRemote
 from shared_file_vault.vault import (
     add_checkout,
     create_niche,
+    get_checkout,
     init_vault,
-    list_checkouts,
     list_niches,
     publish,
     pull_niche,
@@ -181,13 +159,15 @@ def test_concurrent_registry_additions(playground_dir):
     assert alice_niches == bob_niches, "Both participants should converge to the same registry"
 
 
-def test_multiple_checkouts_same_niche(playground_dir):
-    """One niche, two checkout paths on the same device.
+def test_one_checkout_per_niche(playground_dir):
+    """Each niche has at most one checkout on a device.
 
-    After publishing from checkout_a, both checkouts reflect the committed
-    state. The second checkout does not need to be the source of the commit
-    to see its result.
+    Adding a second checkout raises DuplicateCheckoutError. To relocate a
+    checkout, the user must remove the existing one first.
     """
+    import pytest
+    from shared_file_vault.vault import DuplicateCheckoutError
+
     playground = pathlib.Path(playground_dir)
 
     alice_root = setup_vault(playground, "alice", ALICE)
@@ -197,29 +177,22 @@ def test_multiple_checkouts_same_niche(playground_dir):
     checkout_b = playground / "checkout-b"
 
     add_checkout(str(alice_root), ALICE, TEAM, "notes", str(checkout_a))
-    add_checkout(str(alice_root), ALICE, TEAM, "notes", str(checkout_b))
+    assert get_checkout(str(alice_root), ALICE, TEAM, "notes") == str(checkout_a)
 
-    checkouts = list_checkouts(str(alice_root), ALICE, TEAM, "notes")
-    assert len(checkouts) == 2, "Both checkouts should be registered"
-    assert str(checkout_a) in checkouts
-    assert str(checkout_b) in checkouts
-
-    # Write and publish from checkout_a
     write(checkout_a, "ideas.txt", "Build something useful.\n")
     publish(str(alice_root), ALICE, TEAM, "notes", str(checkout_a), message="add ideas")
 
-    # checkout_b shares the same git repo — committed content is reachable
-    assert exists(checkout_b, "ideas.txt"), (
-        "checkout_b should reflect the committed file from checkout_a"
-    )
-    assert read(checkout_b, "ideas.txt") == "Build something useful.\n"
+    # Second attach is refused
+    with pytest.raises(DuplicateCheckoutError):
+        add_checkout(str(alice_root), ALICE, TEAM, "notes", str(checkout_b))
 
-    # Remove one checkout — the other is unaffected
+    # Remove and re-attach at a new location
     remove_checkout(str(alice_root), ALICE, TEAM, "notes", str(checkout_a))
-    remaining = list_checkouts(str(alice_root), ALICE, TEAM, "notes")
-    assert len(remaining) == 1
-    assert str(checkout_b) in remaining
-    assert exists(checkout_b, "ideas.txt"), "checkout_b files should survive checkout_a removal"
+    assert get_checkout(str(alice_root), ALICE, TEAM, "notes") is None
+
+    add_checkout(str(alice_root), ALICE, TEAM, "notes", str(checkout_b))
+    assert get_checkout(str(alice_root), ALICE, TEAM, "notes") == str(checkout_b)
+    assert exists(checkout_b, "ideas.txt"), "new checkout should reflect committed content"
 
 
 def test_full_join_flow(playground_dir):

--- a/packages/shared-file-vault/tests/test_hub_sync.py
+++ b/packages/shared-file-vault/tests/test_hub_sync.py
@@ -300,9 +300,10 @@ def test_hub_push_pull_refreshes_checkout(playground_dir, minio_server_gen, monk
     assert b"notes.txt" not in raw_latest_link
     assert b"v1\n" not in raw_latest_link
 
+    # Bob joins: fetch → attach checkout → merge (3-step join flow)
     monkeypatch.setenv("SMALL_SEA_VAULT_CONFIG", str(root / "bob-vault.toml"))
     sync.login_team("ProjectX", env["bob_hex"], _http_client=http, pin_reader=lambda _: "")
-    sync.pull_via_hub(
+    sync.fetch_via_hub(
         bob_vault_root,
         env["bob_hex"],
         "ProjectX",
@@ -311,6 +312,14 @@ def test_hub_push_pull_refreshes_checkout(playground_dir, minio_server_gen, monk
         _http_client=http,
     )
     vault.add_checkout(bob_vault_root, env["bob_hex"], "ProjectX", "docs", str(bob_checkout))
+    sync.merge_via_hub(
+        bob_vault_root,
+        env["bob_hex"],
+        "ProjectX",
+        "docs",
+        env["alice_member_id_hex"],
+        _http_client=http,
+    )
     assert (bob_checkout / "notes.txt").read_text() == "v1\n"
 
     monkeypatch.setenv("SMALL_SEA_VAULT_CONFIG", str(root / "alice-vault.toml"))
@@ -318,6 +327,7 @@ def test_hub_push_pull_refreshes_checkout(playground_dir, minio_server_gen, monk
     vault.publish(alice_vault_root, env["alice_hex"], "ProjectX", "docs", str(alice_checkout), message="update")
     sync.push_via_hub(alice_vault_root, env["alice_hex"], "ProjectX", "docs", _http_client=http)
 
+    # Subsequent pull: Bob already has a clean checkout, pull_via_hub works directly
     monkeypatch.setenv("SMALL_SEA_VAULT_CONFIG", str(root / "bob-vault.toml"))
     sync.pull_via_hub(
         bob_vault_root,
@@ -352,9 +362,10 @@ def test_hub_pull_conflict_reports_paths(playground_dir, minio_server_gen, monke
     sync.login_team("ProjectX", env["alice_hex"], _http_client=http, pin_reader=lambda _: "")
     sync.push_via_hub(alice_vault_root, env["alice_hex"], "ProjectX", "docs", _http_client=http)
 
+    # Bob joins: fetch → attach checkout → merge (3-step join flow)
     monkeypatch.setenv("SMALL_SEA_VAULT_CONFIG", str(root / "bob-vault.toml"))
     sync.login_team("ProjectX", env["bob_hex"], _http_client=http, pin_reader=lambda _: "")
-    sync.pull_via_hub(
+    sync.fetch_via_hub(
         bob_vault_root,
         env["bob_hex"],
         "ProjectX",
@@ -363,6 +374,14 @@ def test_hub_pull_conflict_reports_paths(playground_dir, minio_server_gen, monke
         _http_client=http,
     )
     vault.add_checkout(bob_vault_root, env["bob_hex"], "ProjectX", "docs", str(bob_checkout))
+    sync.merge_via_hub(
+        bob_vault_root,
+        env["bob_hex"],
+        "ProjectX",
+        "docs",
+        env["alice_member_id_hex"],
+        _http_client=http,
+    )
 
     monkeypatch.setenv("SMALL_SEA_VAULT_CONFIG", str(root / "alice-vault.toml"))
     (alice_checkout / "shared.txt").write_text("alice change\n")

--- a/packages/shared-file-vault/tests/test_sync.py
+++ b/packages/shared-file-vault/tests/test_sync.py
@@ -4,9 +4,10 @@ from cod_sync.protocol import LocalFolderRemote
 from shared_file_vault.vault import (
     add_checkout,
     create_niche,
+    fetch_niche,
     init_vault,
+    merge_niche,
     publish,
-    pull_niche,
     push_niche,
 )
 
@@ -32,13 +33,14 @@ def test_sync_niche_between_devices(playground_dir):
 
     push_niche(root_a, PARTICIPANT, TEAM, "photos", LocalFolderRemote(str(cloud_dir)))
 
-    # --- Device B: pull from cloud (no prior create_niche needed) ---
+    # --- Device B: join flow: fetch → attach checkout → merge ---
     root_b = str(playground / "device-b")
     init_vault(root_b, PARTICIPANT)
     checkout_b = str(playground / "checkout-b" / "photos")
 
-    pull_niche(root_b, PARTICIPANT, TEAM, "photos", LocalFolderRemote(str(cloud_dir)))
+    fetch_niche(root_b, PARTICIPANT, TEAM, "photos", PARTICIPANT, LocalFolderRemote(str(cloud_dir)))
     add_checkout(root_b, PARTICIPANT, TEAM, "photos", checkout_b)
+    merge_niche(root_b, PARTICIPANT, TEAM, "photos", PARTICIPANT)
 
     # --- Assert both checkouts have the same files ---
     sunset_b = pathlib.Path(checkout_b) / "sunset.jpg"

--- a/packages/shared-file-vault/tests/test_vault.py
+++ b/packages/shared-file-vault/tests/test_vault.py
@@ -1,13 +1,22 @@
 import pathlib
 
+import pytest
+
 from shared_file_vault.vault import (
+    DirtyCheckoutError,
+    DuplicateCheckoutError,
+    NoCheckoutError,
     add_checkout,
     create_niche,
+    fetch_niche,
+    get_checkout,
     init_vault,
     list_checkouts,
     list_niches,
     log,
+    merge_niche,
     publish,
+    remove_checkout,
     status,
 )
 
@@ -57,19 +66,39 @@ def test_add_checkout(playground_dir):
     assert str(dest) in checkouts
 
 
-def test_add_multiple_checkouts(playground_dir):
+def test_add_checkout_twice_raises(playground_dir):
+    """A second add_checkout for the same niche raises DuplicateCheckoutError."""
     _init(playground_dir)
     create_niche(playground_dir, PARTICIPANT, TEAM, "notes")
 
     dest_a = pathlib.Path(playground_dir) / "checkout-a"
     dest_b = pathlib.Path(playground_dir) / "checkout-b"
     add_checkout(playground_dir, PARTICIPANT, TEAM, "notes", str(dest_a))
-    add_checkout(playground_dir, PARTICIPANT, TEAM, "notes", str(dest_b))
 
+    with pytest.raises(DuplicateCheckoutError) as exc_info:
+        add_checkout(playground_dir, PARTICIPANT, TEAM, "notes", str(dest_b))
+
+    assert str(dest_a) in exc_info.value.existing_path
+
+    # Only the first checkout is registered
     checkouts = list_checkouts(playground_dir, PARTICIPANT, TEAM, "notes")
-    assert len(checkouts) == 2
+    assert len(checkouts) == 1
     assert str(dest_a) in checkouts
-    assert str(dest_b) in checkouts
+
+
+def test_get_checkout(playground_dir):
+    """get_checkout returns the path or None."""
+    _init(playground_dir)
+    create_niche(playground_dir, PARTICIPANT, TEAM, "notes")
+
+    assert get_checkout(playground_dir, PARTICIPANT, TEAM, "notes") is None
+
+    dest = pathlib.Path(playground_dir) / "checkout"
+    add_checkout(playground_dir, PARTICIPANT, TEAM, "notes", str(dest))
+    assert get_checkout(playground_dir, PARTICIPANT, TEAM, "notes") == str(dest)
+
+    remove_checkout(playground_dir, PARTICIPANT, TEAM, "notes", str(dest))
+    assert get_checkout(playground_dir, PARTICIPANT, TEAM, "notes") is None
 
 
 def test_publish_and_log(playground_dir):
@@ -127,18 +156,137 @@ def test_selective_publish(playground_dir):
     assert "a.txt" not in paths
 
 
-def test_publish_refreshes_sibling_checkouts(playground_dir):
-    """After publishing from checkout_a, checkout_b reflects the new commit."""
+def test_schema_version_recreates_db(playground_dir):
+    """checkouts.db is recreated when the schema version does not match."""
+    import sqlite3
+    from shared_file_vault.vault import _CHECKOUTS_DB_VERSION, _checkouts_db_path
+
+    _init(playground_dir)
+    create_niche(playground_dir, PARTICIPANT, TEAM, "photos")
+    dest = pathlib.Path(playground_dir) / "checkout"
+    add_checkout(playground_dir, PARTICIPANT, TEAM, "photos", str(dest))
+
+    # Corrupt the schema version to simulate a stale DB
+    db_path = _checkouts_db_path(playground_dir, PARTICIPANT)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("UPDATE schema_version SET version = ?", (_CHECKOUTS_DB_VERSION - 1,))
+    conn.commit()
+    conn.close()
+
+    # Next connection should recreate the DB; stale checkout row is gone
+    assert get_checkout(playground_dir, PARTICIPANT, TEAM, "photos") is None
+
+
+# ---------------------------------------------------------------------------
+# merge_niche guard tests
+# These verify that the clean-checkout guard fires on the user's checkout
+# (not on the transit work tree) before any transit operations run.
+# ---------------------------------------------------------------------------
+
+PARTICIPANT_B = "bb" * 16
+
+
+def _two_vault_setup(playground_dir):
+    """Set up alice (PARTICIPANT) and bob (PARTICIPANT_B) vaults sharing a niche."""
+    from cod_sync.protocol import LocalFolderRemote
+    from shared_file_vault.vault import (
+        fetch_niche,
+        push_niche,
+    )
+
+    playground = pathlib.Path(playground_dir)
+
+    # Alice creates niche, writes a file, and pushes
     _init(playground_dir)
     create_niche(playground_dir, PARTICIPANT, TEAM, "shared")
+    alice_co = playground / "checkout-alice"
+    add_checkout(playground_dir, PARTICIPANT, TEAM, "shared", str(alice_co))
+    (alice_co / "hello.txt").write_text("hello\n")
+    publish(playground_dir, PARTICIPANT, TEAM, "shared", str(alice_co), message="init")
 
-    dest_a = pathlib.Path(playground_dir) / "checkout-a"
-    dest_b = pathlib.Path(playground_dir) / "checkout-b"
-    add_checkout(playground_dir, PARTICIPANT, TEAM, "shared", str(dest_a))
-    add_checkout(playground_dir, PARTICIPANT, TEAM, "shared", str(dest_b))
+    cloud = playground / "cloud"
+    cloud.mkdir()
+    push_niche(playground_dir, PARTICIPANT, TEAM, "shared", LocalFolderRemote(str(cloud)))
 
-    (dest_a / "ideas.txt").write_text("Build something useful.\n")
-    publish(playground_dir, PARTICIPANT, TEAM, "shared", str(dest_a), message="add ideas")
+    # Bob gets an empty vault and fetches from alice
+    bob_root = playground / "vault-bob"
+    init_vault(str(bob_root), PARTICIPANT_B)
+    fetch_niche(str(bob_root), PARTICIPANT_B, TEAM, "shared", PARTICIPANT, LocalFolderRemote(str(cloud)))
 
-    assert (dest_b / "ideas.txt").exists()
-    assert (dest_b / "ideas.txt").read_text() == "Build something useful.\n"
+    bob_co = playground / "checkout-bob"
+    add_checkout(str(bob_root), PARTICIPANT_B, TEAM, "shared", str(bob_co))
+
+    return playground, bob_root, bob_co
+
+
+def test_merge_without_checkout_raises(playground_dir):
+    """merge_niche raises NoCheckoutError when no checkout is attached."""
+    from cod_sync.protocol import LocalFolderRemote
+    from shared_file_vault.vault import fetch_niche, push_niche
+
+    playground = pathlib.Path(playground_dir)
+    _init(playground_dir)
+    create_niche(playground_dir, PARTICIPANT, TEAM, "stuff")
+    alice_co = playground / "checkout-alice"
+    add_checkout(playground_dir, PARTICIPANT, TEAM, "stuff", str(alice_co))
+    (alice_co / "a.txt").write_text("a\n")
+    publish(playground_dir, PARTICIPANT, TEAM, "stuff", str(alice_co), message="init")
+
+    cloud = playground / "cloud"
+    cloud.mkdir()
+    push_niche(playground_dir, PARTICIPANT, TEAM, "stuff", LocalFolderRemote(str(cloud)))
+
+    bob_root = playground / "vault-bob"
+    init_vault(str(bob_root), PARTICIPANT_B)
+    fetch_niche(str(bob_root), PARTICIPANT_B, TEAM, "stuff", PARTICIPANT, LocalFolderRemote(str(cloud)))
+
+    # Bob has a fetched ref but no checkout — merge must fail clearly
+    with pytest.raises(NoCheckoutError):
+        merge_niche(str(bob_root), PARTICIPANT_B, TEAM, "stuff", PARTICIPANT)
+
+
+def test_merge_dirty_tracked_file_raises(playground_dir):
+    """merge_niche raises DirtyCheckoutError when the user's checkout has a modified tracked file.
+
+    The guard must target the user's checkout, not the transit work tree
+    (transit resets itself to HEAD and would always appear clean).
+    """
+    playground, bob_root, bob_co = _two_vault_setup(playground_dir)
+
+    # Bob has a fetched ref parked (from _two_vault_setup).
+    # Dirty a tracked file in bob's checkout — this is what must block the merge.
+    (bob_co / "hello.txt").write_text("modified\n")
+
+    with pytest.raises(DirtyCheckoutError) as exc_info:
+        merge_niche(str(bob_root), PARTICIPANT_B, TEAM, "shared", PARTICIPANT)
+
+    assert "hello.txt" in exc_info.value.paths
+
+
+def test_merge_dirty_untracked_file_raises(playground_dir):
+    """merge_niche raises DirtyCheckoutError for untracked files too.
+
+    Untracked files are treated as dirty to avoid path-collision cases and
+    to keep the UX rule simple: the folder must be completely clean.
+    """
+    playground, bob_root, bob_co = _two_vault_setup(playground_dir)
+
+    # Drop an untracked file into bob's checkout
+    (bob_co / "untracked.txt").write_text("surprise\n")
+
+    with pytest.raises(DirtyCheckoutError) as exc_info:
+        merge_niche(str(bob_root), PARTICIPANT_B, TEAM, "shared", PARTICIPANT)
+
+    assert "untracked.txt" in exc_info.value.paths
+
+
+def test_merge_clean_checkout_succeeds(playground_dir):
+    """merge_niche succeeds and refreshes the checkout when it is clean."""
+    playground, bob_root, bob_co = _two_vault_setup(playground_dir)
+
+    # Bob's checkout is clean; merge should succeed and deliver alice's file
+    result_sha = merge_niche(str(bob_root), PARTICIPANT_B, TEAM, "shared", PARTICIPANT)
+
+    assert result_sha is not None
+    assert (bob_co / "hello.txt").exists()
+    assert (bob_co / "hello.txt").read_text() == "hello\n"

--- a/packages/shared-file-vault/tests/test_web_sync.py
+++ b/packages/shared-file-vault/tests/test_web_sync.py
@@ -270,9 +270,10 @@ def test_web_push_and_pull_through_hub(playground_dir, minio_server_gen, monkeyp
     assert push_resp.status_code == 200
     assert "Pushed niche and registry through the Hub." in push_resp.text
 
+    # Bob joins: fetch → attach checkout → merge (3-step join flow)
     monkeypatch.setenv("SMALL_SEA_VAULT_CONFIG", str(root / "bob-vault.toml"))
     sync.login_team("ProjectX", env["bob_hex"], _http_client=http, pin_reader=lambda _: "")
-    sync.pull_via_hub(
+    sync.fetch_via_hub(
         bob_vault_root,
         env["bob_hex"],
         "ProjectX",
@@ -281,6 +282,14 @@ def test_web_push_and_pull_through_hub(playground_dir, minio_server_gen, monkeyp
         _http_client=http,
     )
     vault.add_checkout(bob_vault_root, env["bob_hex"], "ProjectX", "docs", str(bob_checkout))
+    sync.merge_via_hub(
+        bob_vault_root,
+        env["bob_hex"],
+        "ProjectX",
+        "docs",
+        env["alice_member_id_hex"],
+        _http_client=http,
+    )
 
     (alice_checkout / "notes.txt").write_text("hello again\n")
     vault.publish(alice_vault_root, env["alice_hex"], "ProjectX", "docs", str(alice_checkout), message="update")


### PR DESCRIPTION
## Summary

- **One checkout per niche per device** — enforced via SQLite UNIQUE constraint and `DuplicateCheckoutError`; `checkouts.db` gains a `schema_version` table and is recreated on version mismatch
- **Explicit merge semantics** — `merge_niche` / `merge_via_hub` require a clean, attached checkout before touching anything; `pull_niche` likewise; the transit work tree's always-clean state can never masquerade as a green light
- **3-step join flow** — `fetch_niche` (no checkout needed) → `add_checkout` → `merge_niche`; CLI gains `fetch` and `merge` commands; `pull` remains as a convenience wrapper for the already-joined case
- **First-class error types** — `DirtyCheckoutError`, `NoCheckoutError`, `StaleCheckoutError` in both `vault` and `sync` layers; CLI and web surfaces all three with actionable messages; `merge_via_hub` preflights the checkout *before* merging the registry to prevent partial state
- **Missing-path guard** — `_is_checkout_clean` returns `False` for non-existent directories; `_require_clean_checkout` raises `StaleCheckoutError` instead of a raw `ValueError`

## Test plan

- [x] `uv run pytest packages/shared-file-vault/tests -q` → 31 passed, 3 skipped
- [x] `test_one_checkout_per_niche` — duplicate attach raises, remove + re-attach works
- [x] `test_merge_without_checkout_raises`, `test_merge_dirty_tracked_file_raises`, `test_merge_dirty_untracked_file_raises`, `test_merge_clean_checkout_succeeds`
- [x] `test_registry_propagation`, `test_full_join_flow`, `test_concurrent_registry_additions` — 3-step join flow throughout
- [x] `test_hub_push_pull_refreshes_checkout`, `test_hub_pull_conflict_reports_paths`, `test_web_push_and_pull_through_hub` — updated to 3-step join
- [x] `test_schema_version_recreates_db` — stale DB is replaced cleanly

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)