### PR TITLE
Admission onto the shared Constitution envelope (#164)

### DIFF
--- a/Archive/design-record-admission-new-constitution.md
+++ b/Archive/design-record-admission-new-constitution.md
@@ -1,0 +1,157 @@
+# Design record: admission onto the shared envelope (#164)
+
+Moves the one quorum-gated Constitution flow — admission — off the mutable
+`admission_proposal` state machine and onto the shared append-only envelope
+already used by `integration_mode_change`.
+Four record types now carry the flow: `admission_proposal`, `admission_acceptance`,
+`endorsement`, `finalization`.
+Everything mutable is a computed view or a projection, never a mutated record.
+
+## Choices a future developer might want to revisit
+
+### Status is computed, never stored (`_admission_status`)
+
+The proposal row has no `state`/`invalid_reason`/acceptance/finalization columns.
+Status is derived from which records exist:
+`finalized` (a `finalization` row) → `invalidated` (revoked, or governance drift) →
+`expired` (`expires_at` passed) → `awaiting_quorum` (an `admission_acceptance` exists) →
+`awaiting_invitee`.
+Expiry and drift are *computed at read time* and produce a refusal at
+endorse/finalize time (`_admission_action_block_reason`), never an `UPDATE`.
+The old code mutated the row to `expired`/`invalidated` on the same conditions;
+the new behavior is observationally the same for the UI but keeps the record
+immutable. Cost: `_admission_status` recomputes the constitution snapshot digest
+on every call. Fine at research scale; revisit if proposal lists get large.
+
+### `admission_acceptance` is the schema's one self-certifying record
+
+Built and signed invitee-side in `accept_invitation`; the inviter transports it
+and inserts it verbatim after a *self-certifying* verify: recompute canonical
+bytes, verify the signature against the record's own embedded
+`invitee_device_public_key`, and require `author_device_key_id` to be that key's
+id and `record_id` to match the contents.
+The invitee has no `device_link` yet, so there is no cert graph to check against —
+this is the deliberate exception documented in `team-constitution.md`.
+Its envelope `anchor_commit`/`constitution_*` are NULL: the invitee has no
+standing to attest to a governance view.
+
+### `endorsement` dedupes per teammate, not per device (the #164 fix)
+
+`UNIQUE(subject_record_id, author_teammate_id)` + `INSERT OR IGNORE`, so one
+steward's two linked devices (or a repeat) count once. The old
+`steward_approval` keyed on `(proposal_id, approver_device_key_id)`, letting a
+single steward's two devices double-count toward quorum.
+`subject_digest` is the untruncated sha256 over the endorsed acceptance's
+canonical bytes (the acceptance's `record_id` is the first 16 bytes of the same
+hash), generalizing the old `transcript_digest`.
+
+### Merged rows are verified where they are consumed
+
+Rows arrive by sync merge, so presence in the local DB implies nothing about validity: without read-path verification, a forged endorsement row in a real steward's name would satisfy the raw `COUNT(*)` quorum.
+Every admission decision point therefore re-verifies what it reads.
+The invariants:
+
+- Quorum counts only endorsements that verify end-to-end (`_count_valid_endorsements`): signature over recomputed canonical bytes, `author_device_key_id` hashes from the device public key, `subject_digest` equals the recomputed acceptance commitment, the endorsement anchors at the proposal's own `constitution_digest`, and the (teammate, device) pair is an automatic Core integrator in the proposal's snapshot.
+- `constitution_snapshot_json` is parsed only via `_verified_proposal_snapshot`, which checks it against the signed `constitution_digest` first.
+- `endorse_admission`, `complete_invitation_acceptance`, and `finalize_admission` re-verify the proposal row (`_verify_proposal_row`) and the acceptance row (`_verify_acceptance_row`, the same self-certifying checks run on the transported token) before acting — merged rows are never trusted as already-checked local state.
+- A proposal is `finalized` only if `_valid_finalization_exists`: some finalization row verifies one-hop — recomputed `record_id`, key-bound signature, author == the proposal's author (the inviter-only rule), `subject_digest` == the acceptance commitment.
+  Bare row presence would let a forged merged finalization freeze the proposal ("already finalized" at every decision point) while the UI showed success with no projections anywhere.
+  `finalization` has no `UNIQUE(subject_record_id)`, so invalid rows are ignored and the legitimate finalization is appended alongside them.
+- Every governance-bearing record binds its author *device* to its claimed author *teammate*; without that binding, an insider can sign with their own registered device while claiming another teammate as author (misattributed proposals, insider finalization freezes).
+  The binding source differs per record on purpose: `_valid_finalization_exists` checks the finalizer's device against the proposal's snapshot (`teammate_devices`), which is safe (any later device change drift-refuses the proposal) and strong (the snapshot rides the row whose content-derived `record_id` the whole chain FKs against); `_verify_proposal_row` checks `team_device.teammate_id` instead, because the proposal's own snapshot is self-referential — a forger signs whatever snapshot they like into a forged row.
+  Endorsements carry the binding via snapshot eligibility; acceptance is exempt by design (the self-certification exception).
+- The device-binding argument is non-circular only because `_valid_finalization_exists` runs `_verify_proposal_row` before trusting the proposal's author or snapshot: `record_id` is a *stored* column, so its binding to row content exists only where `derive_record_id(canonical) == record_id` actually runs.
+  Without that check, an in-place UPDATE of the proposal row (same PK, swapped author, optionally a self-consistent crafted digest+snapshot) re-roots the device binding at attacker-chosen data, letting a validly signed finalization from the new "author" read as terminal.
+  The predicate degrades to False (never raising) so status display survives tampered rows.
+- The inviter's auto-endorsement at acceptance time is gated on the same integrator eligibility, so the code never authors an endorsement the counter would refuse.
+
+Deliberate non-checks and known boundaries:
+
+- A finalization's `constitution_digest` is not compared with the proposal's: a legitimate finalization anchors the *post-projection* snapshot, which always differs (also why `finalized` is decided before drift in `_admission_status`).
+- Finalization validity does not re-count quorum: the threshold is currently mutable, so re-checking would retroactively invalidate legitimate finalizations when quorum is raised; the signed `endorsement_count` claim gets audited by #167's replay.
+  Consequence, stated openly: a malicious *inviter* can sign a no-quorum finalization — the finalizer is the trusted principal in this slice (follow-up notes).
+- Tampered `expires_at`/digest columns still freeze a proposal as `expired`/`invalidated` before any verification runs.
+  Asymmetry kept deliberately: those tampers produce *refusal*, the conservative direction, and an in-place-tampered proposal is dead on that replica regardless; only the finalization branch could convert an unverified row into a false positive.
+- `_count_valid_endorsements` relies on every caller handing it an already-verified proposal row.
+- All of this is one-hop verification (device keys authenticated by key-id binding against the proposal's signed snapshot, no chain-follow to genesis); the chain-of-trust story is #166/#167 — see the follow-up notes.
+- `_endorsement_count` (raw) survives only for the event-feed display.
+  Status computation verifies signatures per call (finalization rows, at minimum); fine at research scale, same note as the snapshot-digest recompute above.
+
+### Only `finalization` makes a proposal effective
+
+At quorum 1 (default), `complete_invitation_acceptance` inserts the acceptance,
+auto-endorses as the inviter, and finalizes inline.
+At quorum ≥ 2 the acceptance alone yields `awaiting_quorum` with **no** projection
+writes — a stronger property than the old code, where a quorum-met acceptance
+finalized silently. All projection writes (`teammate`/`team_device`/cert/
+`berth_role`) key off inserting the `finalization` row.
+
+### Preset → per-berth `mode_plan` expansion (D5)
+
+The `steward`/`contributor` preset is a UI presentation string translated to an
+expansion *rule* at the manager boundary (`mode_plan_for_preset`):
+`{"core_mode": ..., "other_mode": ...}` with `automatic`/`proposal-only` values.
+It rides on the proposal as a **signed, NOT NULL** `mode_plan` column so a
+different steward on a different device can finalize with the inviter's intent
+intact, without storing Manager preset vocabulary.
+The plan must be signed because it is the sole input to the authority granted at finalization: an unsigned plan could be escalated undetected, with the tamper laundered into honestly-signed `integration_mode_change` records.
+Signing it also means every endorsement commits to the plan for free, since `subject_record_id` is a content digest of the proposal.
+Rejected alternative: committing to the plan via the endorsement's `subject_digest` only — that binds it from first endorsement onward, leaving the creation-to-acceptance window open in the quorum-1 auto-finalize path.
+There is no default plan at finalization: a missing/malformed plan refuses rather than granting the steward expansion.
+At finalization it expands to one signed `integration_mode_change` record per
+berth for the invitee — `core_mode` on Core, `other_mode` elsewhere — reusing
+`_append_integration_mode_change` (extracted from `set_teammate_integration_mode`),
+which also writes the `berth_role` projection.
+This fixes a documented mismatch: the old `_role_to_core_berth_role` gave a
+contributor `read-only` on *every* berth; `architecture.md` specifies
+`proposal-only` on Core and `automatic` elsewhere.
+
+Deliberate authority asymmetry in the expansion: `set_teammate_integration_mode` requires its author to hold automatic standing on the berth it changes, but finalization's expansion skips that check.
+The finalizer's authority is the met quorum, not per-berth standing — they may legitimately grant the invitee `automatic` on a berth where they themselves are only `proposal-only`.
+If a future slice wants finalization to respect per-berth authority, that predicate moves into the shared builder with a caller opt-out.
+
+### Drift is deliberately strict this slice
+
+`constitution_snapshot` covers all berth roles, so adding a berth mid-proposal
+changes the digest and endorsement/finalization refuse — "expand across the
+current berth set" only ever sees the berths the endorsers saw.
+Narrowing drift to admission-relevant authority is a live research question
+(follow-up notes, pointed at #166).
+
+### Revocation is a projection, not a record
+
+`revoke_invitation` inserts an `admission_revocation` row (a mutable
+disposition) rather than mutating the proposal; `_admission_status` reads it as
+`invalidated`. A signed revocation record is out of scope (follow-up notes).
+
+## Divergences from `Documentation/team-constitution.md`
+
+Cross-checked column-by-column; three intentional divergences found.
+Two were doc errors and the doc was amended on this branch to match the implementation:
+
+1. **`invitee_device_public_key` placement.**
+   The doc listed it as an `admission_proposal` column, but that key does not exist until acceptance — it lives only on `admission_acceptance` (where the doc also, correctly, uses it as the self-certification key).
+   The proposal is signed at creation and cannot embed it.
+2. **Signed `mode_plan` on the proposal.**
+   The doc said the preset is "not a field on the proposal itself"; the implementation stores the signed per-berth expansion rule (mode vocabulary, never the preset name) on the proposal, because the plan determines granted authority and must carry the inviter's signature.
+   Mode *facts* are still established only by `integration_mode_change` records at finalization.
+
+One divergence remains, deliberately: **interim anchor** — like `integration_mode_change`, records use the phase-1 `constitution_digest`/`constitution_snapshot_json` stand-in, not the target `anchor_frontier` (#166).
+
+## Repo-integrity notes
+
+- Zero new canonical-bytes idioms: all four types go through
+  `wrasse_trust.constitution`. This branch *removes* the admission-local
+  `_approval_payload`/`_finalization_payload`/`_proposal_transcript_*` signing
+  helpers and the `_governance_snapshot`/`_governance_digest` pair.
+- `set_teammate_integration_mode` and admission finalization now share one
+  record-builder (`_append_integration_mode_change`).
+- `USER_SCHEMA_VERSION` 62 → 64, no migration (pre-alpha stance); `steward_approval`
+  dropped, three record tables + one revocation projection + scan indexes added.
+- `sign_steward_approval` → `endorse_admission`, no compat shim; the HTTP route
+  path `/approve` is unchanged (only the handler internals moved).
+- Append-only audit:
+  `grep -rniE '\b(UPDATE|DELETE FROM)\s+(admission_proposal|admission_acceptance|endorsement|finalization)\b' packages/small-sea-manager/small_sea_manager/`
+  is clean (0 hits). Scoped to the package *source* deliberately: the tamper
+  micro tests in `tests/test_admission_records.py` mutate these tables on
+  purpose, so widening the scope re-flags them by design, not by defect.

--- a/Documentation/team-constitution.md
+++ b/Documentation/team-constitution.md
@@ -104,9 +104,11 @@ A record whose frontier is merely no longer the *current* tip (newer records hav
 ### Generalized: the one quorum-gated flow
 
 - **`admission_proposal`** — the existing table (see `Archive/design-record-team-constitution-schema.md`), moved onto the shared envelope.
-  Type-specific columns: `nonce`, `invitee_teammate_id` (freshly allocated), `invitee_label_commitment` (signed) and `invitee_label_payload` (separable — see *PII handling* below), `invitee_device_public_key`, `expires_at`.
+  Type-specific columns: `nonce`, `invitee_teammate_id` (freshly allocated), `invitee_label_commitment` (signed) and `invitee_label_payload` (separable — see *PII handling* below), `expires_at`.
+  (`invitee_device_public_key` is not a proposal column: that key does not exist until the invitee accepts, so it lives only on `admission_acceptance`, where it serves as the self-certification key.)
   Drops `role`: admission no longer carries an integration-mode preset directly (see `integration_mode_change` below).
-  The Manager UI still offers a `steward`/`contributor` *preset* at invitation time, but it is realized as a set of `integration_mode_change` records appended alongside finalization, not a field on the proposal itself.
+  The Manager UI still offers a `steward`/`contributor` *preset* at invitation time, but the preset name is not stored on the proposal: the proposal carries only the signed per-berth expansion rule (`mode_plan`), realized as a set of `integration_mode_change` records appended alongside finalization.
+  The rule is signed because the plan is the sole input to the authority granted at finalization; an unsigned plan could be escalated undetected between creation and finalization.
   This keeps "who is admitted" and "what mode do they start in" as separately inspectable facts.
 - **`admission_acceptance`** — new, replacing the mutated acceptance columns on today's `admission_proposal` row.
   References `subject_record_id` (= `admission_proposal.record_id`), the same FK column name and target `endorsement` and `finalization` use below, so all three types that reference a proposal do so identically rather than three different ways.

--- a/packages/small-sea-manager/small_sea_manager/admission_events.py
+++ b/packages/small-sea-manager/small_sea_manager/admission_events.py
@@ -115,30 +115,41 @@ def _linked_device_events(conn, dismissed, *, self_teammate_id_hex: str | None):
 def _invitation_events(conn, dismissed, *, self_teammate_id_hex: str | None, viewer_is_steward: bool):
     proposal_rows = conn.execute(
         text(
-            "SELECT proposal_id, state, invitee_label, role, created_at, finalized_at, "
-            "invitee_teammate_id, inviter_teammate_id, transcript_digest "
-            "FROM admission_proposal "
-            "WHERE state IN ('awaiting_invitee', 'awaiting_quorum', 'finalized') "
-            "ORDER BY COALESCE(finalized_at, created_at) DESC, proposal_id DESC"
+            "SELECT record_id, author_teammate_id, invitee_teammate_id, invitee_label_payload, "
+            "mode_plan, created_at, constitution_digest, expires_at "
+            "FROM admission_proposal ORDER BY created_at DESC, record_id DESC"
         )
     ).fetchall()
 
     if proposal_rows:
         events: list[AdmissionEvent] = []
+        quorum_target = int(provisioning._team_setting(conn, "admission_quorum", "1"))
         for (
-            proposal_id,
-            state,
-            invitee_label,
-            role,
-            created_at,
-            finalized_at,
-            invitee_teammate_id,
+            record_id,
             inviter_teammate_id,
-            transcript_digest,
+            invitee_teammate_id,
+            invitee_label,
+            mode_plan_json,
+            created_at,
+            constitution_digest,
+            expires_at,
         ) in proposal_rows:
-            artifact_id_hex = proposal_id.hex()
+            # Status is a computed view over which admission records exist
+            # (see provisioning._admission_status), never a stored column.
+            status = provisioning._admission_status(
+                conn,
+                record_id=record_id,
+                constitution_digest=constitution_digest,
+                expires_at=expires_at,
+            )
+            artifact_id_hex = record_id.hex()
             teammate_id_hex = invitee_teammate_id.hex() if invitee_teammate_id is not None else None
-            if state == "awaiting_invitee":
+            role = (
+                provisioning.preset_for_mode_plan(json.loads(mode_plan_json))
+                if mode_plan_json
+                else None
+            ) or "custom"
+            if status == "awaiting_invitee":
                 event_type = AdmissionEventType.PROPOSAL_SHELL
                 if (event_type.value, artifact_id_hex) in dismissed:
                     continue
@@ -149,7 +160,7 @@ def _invitation_events(conn, dismissed, *, self_teammate_id_hex: str | None, vie
                         occurred_at=created_at,
                         title=f"Proposal shell open for {invitee_label or 'unlabelled invitee'}",
                         summary=(
-                            f"Transcript-bound admission proposal created for role `{role}`. "
+                            f"Admission proposal created for role `{role}`. "
                             "This shell should be visible before the invitation token is delivered."
                         ),
                         badge_label="proposal shell",
@@ -162,24 +173,11 @@ def _invitation_events(conn, dismissed, *, self_teammate_id_hex: str | None, vie
                     )
                 )
                 continue
-            if state == "awaiting_quorum":
+            if status == "awaiting_quorum":
                 event_type = AdmissionEventType.AWAITING_QUORUM
                 if (event_type.value, artifact_id_hex) in dismissed:
                     continue
-                quorum_row = conn.execute(
-                    text(
-                        "SELECT COUNT(DISTINCT steward_teammate_id) FROM steward_approval "
-                        "WHERE proposal_id = :proposal_id AND transcript_digest = :transcript_digest"
-                    ),
-                    {
-                        "proposal_id": proposal_id,
-                        "transcript_digest": transcript_digest,
-                    },
-                ).fetchone()
-                quorum_count = int(quorum_row[0]) if quorum_row is not None else 0
-                quorum_target = int(
-                    provisioning._team_setting(conn, "admission_quorum", "1")
-                )
+                quorum_count = provisioning._endorsement_count(conn, record_id)
                 can_finalize = (
                     viewer_is_steward
                     and self_teammate_id_hex is not None
@@ -194,8 +192,8 @@ def _invitation_events(conn, dismissed, *, self_teammate_id_hex: str | None, vie
                         occurred_at=created_at,
                         title=f"Awaiting quorum for {invitee_label or 'unlabelled invitee'}",
                         summary=(
-                            f"Transcript recorded for role `{role}`. "
-                            f"{quorum_count} of {quorum_target} distinct steward approvals recorded."
+                            f"Acceptance recorded for role `{role}`. "
+                            f"{quorum_count} of {quorum_target} endorsements recorded."
                         ),
                         badge_label="awaiting quorum",
                         badge_class="badge-amber",
@@ -209,18 +207,23 @@ def _invitation_events(conn, dismissed, *, self_teammate_id_hex: str | None, vie
                     )
                 )
                 continue
-            if state == "finalized":
+            if status == "finalized":
                 event_type = AdmissionEventType.INVITATION_FINALIZED
                 if (event_type.value, artifact_id_hex) in dismissed:
                     continue
+                fin_row = conn.execute(
+                    text("SELECT created_at FROM finalization WHERE subject_record_id = :id"),
+                    {"id": record_id},
+                ).fetchone()
+                finalized_at = fin_row[0] if fin_row is not None else created_at
                 events.append(
                     AdmissionEvent(
                         event_type=event_type,
                         artifact_id_hex=artifact_id_hex,
-                        occurred_at=finalized_at or created_at,
+                        occurred_at=finalized_at,
                         title=f"Admission finalized for {invitee_label or _teammate_label(None, teammate_id_hex)}",
                         summary=(
-                            "This transcript-bound admission has been finalized in the current team view. "
+                            "This admission has been finalized in the current team view. "
                             "Transport setup remains a separate post-admission step."
                         ),
                         badge_label="finalized",

--- a/packages/small-sea-manager/small_sea_manager/manager.py
+++ b/packages/small-sea-manager/small_sea_manager/manager.py
@@ -398,11 +398,16 @@ class TeamManager:
     # --- Invitations ---
 
     def create_invitation(self, team_name, invitee_label=None, role="steward"):
-        """Create an invitation token for someone to join a team."""
+        """Create an invitation token for someone to join a team.
+
+        `role` is the UI preset (steward/contributor); it is translated to the
+        per-berth mode-plan expansion rule at this boundary.
+        """
         cloud = provisioning.get_cloud_storage(self.root_dir, self.participant_hex)
         return provisioning.create_invitation(
             self.root_dir, self.participant_hex, team_name, cloud,
-            invitee_label=invitee_label, role=role,
+            invitee_label=invitee_label,
+            mode_plan=provisioning.mode_plan_for_preset(role),
         )
 
     def authorize_identity_join(self, join_request_artifact_b64, *, expires_in_seconds=600):
@@ -687,9 +692,9 @@ class TeamManager:
             self.root_dir, self.participant_hex, team_name, acceptance_b64
         )
 
-    def sign_steward_approval(self, team_name, proposal_id):
-        """Record this steward's approval for a transcript-bound admission proposal."""
-        provisioning.sign_steward_approval(
+    def endorse_admission(self, team_name, proposal_id):
+        """Record this teammate's endorsement of an admission proposal."""
+        provisioning.endorse_admission(
             self.root_dir,
             self.participant_hex,
             team_name,

--- a/packages/small-sea-manager/small_sea_manager/provisioning.py
+++ b/packages/small-sea-manager/small_sea_manager/provisioning.py
@@ -119,6 +119,7 @@ from wrasse_trust.constitution import (
     canonical_constitution_bytes,
     derive_record_id,
     sign_constitution_record,
+    verify_constitution_record,
 )
 from wrasse_trust.identity import (
     CertType,
@@ -876,136 +877,95 @@ def _proposal_expiry(now: datetime, expiry_seconds: int) -> str:
     return datetime.fromtimestamp(now.timestamp() + expiry_seconds, timezone.utc).isoformat()
 
 
-def _proposal_transcript_payload(
+# --- Admission preset <-> mode-plan translation -------------------------------
+#
+# Presets are presentation strings translated to the per-berth expansion rule
+# at the UI boundary (see architecture.md: presets "are not protocol state").
+# The rule stores `automatic`/`proposal-only` values, not preset names, and is
+# indifferent to which berths exist at expansion time.
+_PRESET_MODE_PLANS: dict[str, dict[str, str]] = {
+    "steward": {"core_mode": "automatic", "other_mode": "automatic"},
+    "contributor": {"core_mode": "proposal-only", "other_mode": "automatic"},
+}
+
+
+def mode_plan_for_preset(preset: str) -> dict[str, str]:
+    try:
+        return dict(_PRESET_MODE_PLANS[preset])
+    except KeyError:
+        raise ValueError(f"Unknown invitation preset: {preset!r}")
+
+
+def preset_for_mode_plan(plan: dict[str, str] | None) -> str | None:
+    for preset, expansion in _PRESET_MODE_PLANS.items():
+        if plan == expansion:
+            return preset
+    return None
+
+
+def _validate_mode_plan(plan) -> None:
+    if (
+        not isinstance(plan, dict)
+        or set(plan) != {"core_mode", "other_mode"}
+        or not all(mode in ("automatic", "proposal-only") for mode in plan.values())
+    ):
+        raise ValueError(f"Invalid mode plan: {plan!r}")
+
+
+def _core_berth_id(conn) -> bytes | None:
+    row = conn.execute(
+        text(
+            "SELECT tab.id FROM team_app_berth tab "
+            "JOIN app a ON a.id = tab.app_id "
+            "WHERE a.name = 'SmallSeaCollectiveCore'"
+        )
+    ).fetchone()
+    return row[0] if row is not None else None
+
+
+# --- Constitution record envelope + admission record builders -----------------
+#
+# All four admission record types (proposal/acceptance/endorsement/finalization)
+# share this envelope prefix and go through wrasse_trust.constitution -- no
+# admission-local canonical-bytes idiom. See Documentation/team-constitution.md.
+
+
+def _record_envelope_fields(
     *,
-    proposal_id: bytes,
+    record_type: str,
+    author_teammate_id: bytes,
+    author_device_key_id: bytes,
+    created_at: str,
+    anchor_commit: str | None,
+    constitution_digest: bytes | None,
+    schema_version: int = 1,
+) -> dict:
+    return {
+        "record_type": record_type,
+        "author_teammate_id": author_teammate_id.hex(),
+        "author_device_key_id": author_device_key_id.hex(),
+        "created_at": created_at,
+        "anchor_commit": anchor_commit,
+        "constitution_digest": constitution_digest.hex() if constitution_digest is not None else None,
+        "schema_version": schema_version,
+    }
+
+
+def _acceptance_signed_fields(
+    *,
+    envelope: dict,
+    subject_record_id: bytes,
     nonce: bytes,
-    team_id: bytes,
-    invitee_teammate_id: bytes,
     invitee_device_public_key: bytes,
     invitee_bootstrap_key: bytes,
-) -> dict[str, str]:
+) -> dict:
     return {
-        "proposal_id": proposal_id.hex(),
+        **envelope,
+        "subject_record_id": subject_record_id.hex(),
         "nonce": nonce.hex(),
-        "team_id": team_id.hex(),
-        "invitee_teammate_id": invitee_teammate_id.hex(),
         "invitee_device_public_key": invitee_device_public_key.hex(),
         "invitee_bootstrap_key": invitee_bootstrap_key.hex(),
     }
-
-
-def _proposal_transcript_digest(payload: dict[str, str]) -> bytes:
-    return _sha256_bytes(_json_bytes(payload))
-
-
-def _approval_payload(*, proposal_id: bytes, transcript_digest: bytes, steward_teammate_id: bytes) -> bytes:
-    return _json_bytes(
-        {
-            "proposal_id": proposal_id.hex(),
-            "transcript_digest": transcript_digest.hex(),
-            "steward_teammate_id": steward_teammate_id.hex(),
-        }
-    )
-
-
-def _finalization_payload(*, proposal_id: bytes, transcript_digest: bytes, invitee_teammate_id: bytes) -> bytes:
-    return _json_bytes(
-        {
-            "proposal_id": proposal_id.hex(),
-            "transcript_digest": transcript_digest.hex(),
-            "invitee_teammate_id": invitee_teammate_id.hex(),
-        }
-    )
-
-
-def _role_to_core_berth_role(role: str) -> str:
-    if role == "steward":
-        return "read-write"
-    if role == "contributor":
-        return "read-only"
-    raise ValueError(f"Unknown invitation role: {role}")
-
-
-def _governance_snapshot(conn) -> dict[str, object]:
-    teammate_ids = [row[0].hex() for row in conn.execute(text("SELECT id FROM teammate ORDER BY id")).fetchall()]
-    steward_ids = [
-        row[0].hex()
-        for row in conn.execute(
-            text(
-                "SELECT br.teammate_id "
-                "FROM berth_role br "
-                "JOIN team_app_berth tab ON tab.id = br.berth_id "
-                "JOIN app a ON a.id = tab.app_id "
-                "WHERE a.name = 'SmallSeaCollectiveCore' AND br.role = 'read-write' "
-                "ORDER BY br.teammate_id"
-            )
-        ).fetchall()
-    ]
-    teammate_devices: dict[str, list[str]] = {teammate_id_hex: [] for teammate_id_hex in teammate_ids}
-    for teammate_id, device_key_id in conn.execute(
-        text("SELECT teammate_id, device_key_id FROM team_device ORDER BY teammate_id, device_key_id")
-    ).fetchall():
-        teammate_devices.setdefault(teammate_id.hex(), []).append(device_key_id.hex())
-    return {
-        "stewards": steward_ids,
-        "teammates": teammate_ids,
-        "teammate_devices": teammate_devices,
-    }
-
-
-def _governance_digest(snapshot: dict[str, object]) -> bytes:
-    return _sha256_bytes(_json_bytes(snapshot))
-
-
-def _load_admission_proposal_row(conn, proposal_id: bytes):
-    row = conn.execute(
-        text(
-            "SELECT proposal_id, nonce, team_id, inviter_teammate_id, invitee_teammate_id, "
-            "invitee_label, role, anchor_commit, governance_digest, governance_snapshot_json, "
-            "state, created_at, expires_at, acceptance_recorded_at, invitee_device_public_key, "
-            "invitee_bootstrap_key, acceptance_signature, transcript_digest, transcript_json, "
-            "finalized_at, finalization_signature, invalid_reason "
-            "FROM admission_proposal WHERE proposal_id = :proposal_id"
-        ),
-        {"proposal_id": proposal_id},
-    ).fetchone()
-    if row is None:
-        raise ValueError("Admission proposal not found")
-    return row
-
-
-def _load_governance_snapshot_json(proposal_row) -> dict[str, object]:
-    return json.loads(proposal_row[9])
-
-
-def _proposal_is_still_valid(conn, proposal_row) -> tuple[bool, str | None]:
-    state = proposal_row[10]
-    if state == "finalized":
-        return False, "Proposal is already finalized"
-    if state in {"invalidated", "expired"}:
-        return False, f"Proposal is already {state}"
-    now_iso = _now_iso()
-    if proposal_row[12] < now_iso:
-        conn.execute(
-            text(
-                "UPDATE admission_proposal SET state = 'expired', invalid_reason = 'expired' "
-                "WHERE proposal_id = :proposal_id"
-            ),
-            {"proposal_id": proposal_row[0]},
-        )
-        return False, "Proposal has expired"
-    current_snapshot = _governance_snapshot(conn)
-    if _governance_digest(current_snapshot) != proposal_row[8]:
-        conn.execute(
-            text(
-                "UPDATE admission_proposal SET state = 'invalidated', "
-                "invalid_reason = 'governance_drift' WHERE proposal_id = :proposal_id"
-            ),
-            {"proposal_id": proposal_row[0]},
-        )
-        return False, "Proposal invalidated by governance drift"
-    return True, None
 
 
 def _proposal_quorum(conn) -> int:
@@ -1013,65 +973,535 @@ def _proposal_quorum(conn) -> int:
     return quorum
 
 
-def _approval_count(conn, proposal_id: bytes, transcript_digest: bytes) -> int:
-    # Quorum counting trusts rows that made it into the shared DB. We do not
-    # re-verify signatures here on every count because this branch still relies
-    # on the sync/write-acceptance model rather than an isolated authority layer.
+def _load_proposal_row(conn, record_id: bytes):
     row = conn.execute(
         text(
-            "SELECT COUNT(DISTINCT steward_teammate_id) "
-            "FROM steward_approval "
-            "WHERE proposal_id = :proposal_id AND transcript_digest = :transcript_digest"
+            "SELECT record_id, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, constitution_snapshot_json, nonce, team_id, "
+            "invitee_teammate_id, invitee_label_commitment, expires_at, signature, "
+            "invitee_label_payload, mode_plan "
+            "FROM admission_proposal WHERE record_id = :record_id"
         ),
-        {"proposal_id": proposal_id, "transcript_digest": transcript_digest},
+        {"record_id": record_id},
+    ).fetchone()
+    if row is None:
+        raise ValueError("Admission proposal not found")
+    return row
+
+
+def _load_acceptance_row(conn, subject_record_id: bytes):
+    return conn.execute(
+        text(
+            "SELECT record_id, record_type, author_teammate_id, author_device_key_id, "
+            "created_at, anchor_commit, constitution_digest, schema_version, subject_record_id, "
+            "nonce, invitee_device_public_key, invitee_bootstrap_key, signature "
+            "FROM admission_acceptance WHERE subject_record_id = :sid"
+        ),
+        {"sid": subject_record_id},
+    ).fetchone()
+
+
+def _acceptance_canonical_from_row(row) -> bytes:
+    envelope = {
+        "record_type": row[1],
+        "author_teammate_id": row[2].hex(),
+        "author_device_key_id": row[3].hex(),
+        "created_at": row[4],
+        "anchor_commit": row[5],
+        "constitution_digest": row[6].hex() if row[6] is not None else None,
+        "schema_version": row[7],
+    }
+    return canonical_constitution_bytes(
+        _acceptance_signed_fields(
+            envelope=envelope,
+            subject_record_id=row[8],
+            nonce=row[9],
+            invitee_device_public_key=row[10],
+            invitee_bootstrap_key=row[11],
+        )
+    )
+
+
+def _endorsement_count(conn, subject_record_id: bytes) -> int:
+    """Raw row count, for display (event feed) only. Quorum decisions must use
+    _count_valid_endorsements: merged rows are unverified until then.
+    """
+    row = conn.execute(
+        text("SELECT COUNT(*) FROM endorsement WHERE subject_record_id = :sid"),
+        {"sid": subject_record_id},
     ).fetchone()
     return int(row[0]) if row is not None else 0
 
 
-def _proposal_has_quorum(conn, proposal_row) -> bool:
-    transcript_digest = proposal_row[17]
-    if transcript_digest is None:
+# --- Decision-point record verification ----------------------------------- #
+#
+# Admission rows arrive by git merge as well as by local INSERT, so every
+# decision (endorse, finalize) re-verifies the rows it acts on instead of
+# trusting the table. This is one-hop verification: each record is checked
+# against the proposal's signed snapshot and the device keys it names, not
+# chain-followed back to the team's genesis -- that is the anchor_frontier
+# work (#166) and the projection rebuild (#167).
+
+
+def _device_public_key_for(conn, device_key_id: bytes) -> bytes | None:
+    row = conn.execute(
+        text("SELECT public_key FROM team_device WHERE device_key_id = :id"),
+        {"id": device_key_id},
+    ).fetchone()
+    return row[0] if row is not None else None
+
+
+def _proposal_canonical_from_row(row) -> bytes:
+    signed = {
+        **_record_envelope_fields(
+            record_type="admission_proposal",
+            author_teammate_id=row[1],
+            author_device_key_id=row[2],
+            created_at=row[3],
+            anchor_commit=row[4],
+            constitution_digest=row[5],
+        ),
+        "nonce": row[7].hex(),
+        "team_id": row[8].hex(),
+        "invitee_teammate_id": row[9].hex(),
+        "invitee_label_commitment": row[10].hex() if row[10] is not None else None,
+        "expires_at": row[11],
+        "mode_plan": json.loads(row[14]) if row[14] is not None else None,
+    }
+    return canonical_constitution_bytes(signed)
+
+
+def _verify_proposal_row(conn, proposal_row) -> None:
+    """Re-verify a (possibly merged) proposal row before acting on it.
+
+    The author's public key comes from the team_device projection, but the
+    binding is authenticated: the key must hash to the signed
+    author_device_key_id, so a swapped projection row cannot substitute a key.
+    The device must also belong to the claimed author teammate -- checked
+    against team_device rather than the proposal's own snapshot, which is
+    self-referential here (a forger signs whatever snapshot they like into
+    their forged row) -- so an insider cannot attribute their own signature
+    to another teammate.
+    """
+    canonical = _proposal_canonical_from_row(proposal_row)
+    if derive_record_id(canonical) != proposal_row[0]:
+        raise ValueError("Proposal record_id does not match its contents")
+    device_row = conn.execute(
+        text("SELECT public_key, teammate_id FROM team_device WHERE device_key_id = :id"),
+        {"id": proposal_row[2]},
+    ).fetchone()
+    if device_row is None or key_id_from_public(device_row[0]) != proposal_row[2]:
+        raise ValueError("Proposal author device is not a recognized team device")
+    if device_row[1] != proposal_row[1]:
+        raise ValueError("Proposal author device does not belong to the author teammate")
+    if not verify_constitution_record(device_row[0], canonical, proposal_row[12]):
+        raise ValueError("Proposal signature is invalid")
+
+
+def _verified_proposal_snapshot(proposal_row) -> dict:
+    """Parse constitution_snapshot_json only after it matches the signed digest."""
+    snapshot = json.loads(proposal_row[6])
+    if _constitution_digest(snapshot) != proposal_row[5]:
+        raise ValueError("Proposal constitution snapshot does not match its signed digest")
+    return snapshot
+
+
+def _verify_acceptance_row(acceptance_row, proposal_row) -> None:
+    """Self-certifying re-verify of a (possibly merged) acceptance row,
+    mirroring the checks complete_invitation_acceptance ran on the token."""
+    embedded_key = acceptance_row[10]
+    if key_id_from_public(embedded_key) != acceptance_row[3]:
+        raise ValueError("Acceptance author_device_key_id does not match its embedded device key")
+    canonical = _acceptance_canonical_from_row(acceptance_row)
+    if derive_record_id(canonical) != acceptance_row[0]:
+        raise ValueError("Acceptance record_id does not match its contents")
+    if not verify_constitution_record(embedded_key, canonical, acceptance_row[12]):
+        raise ValueError("Acceptance signature is invalid")
+    if acceptance_row[9] != proposal_row[7]:
+        raise ValueError("Acceptance nonce does not match proposal")
+    if acceptance_row[2] != proposal_row[9]:
+        raise ValueError("Acceptance author does not match the proposal's invitee")
+
+
+def _count_valid_endorsements(conn, proposal_row, acceptance_row) -> int:
+    """Quorum input: only endorsements that verify end-to-end count.
+
+    Per row: subject_digest must be the commitment over the recorded
+    acceptance, the endorsement must anchor at the proposal's own
+    constitution digest, the (teammate, device) pair must be an automatic
+    Core integrator in the proposal's verified snapshot, and the signature
+    must verify against the device key (bound by key id, as in
+    _verify_proposal_row). Distinct teammates, matching the UNIQUE dedupe.
+    """
+    expected_subject_digest = _sha256_bytes(_acceptance_canonical_from_row(acceptance_row))
+    snapshot = _verified_proposal_snapshot(proposal_row)
+    integrators = _snapshot_core_integrator_devices(conn, snapshot)
+    rows = conn.execute(
+        text(
+            "SELECT record_id, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, subject_record_id, subject_digest, signature "
+            "FROM endorsement WHERE subject_record_id = :sid"
+        ),
+        {"sid": proposal_row[0]},
+    ).fetchall()
+    valid_endorsers: set[str] = set()
+    for (
+        record_id,
+        author_teammate_id,
+        author_device_key_id,
+        created_at,
+        anchor_commit,
+        constitution_digest,
+        subject_record_id,
+        subject_digest,
+        signature,
+    ) in rows:
+        if subject_digest != expected_subject_digest:
+            continue
+        if constitution_digest != proposal_row[5]:
+            continue
+        if author_device_key_id.hex() not in integrators.get(author_teammate_id.hex(), set()):
+            continue
+        public_key = _device_public_key_for(conn, author_device_key_id)
+        if public_key is None or key_id_from_public(public_key) != author_device_key_id:
+            continue
+        signed = {
+            **_record_envelope_fields(
+                record_type="endorsement",
+                author_teammate_id=author_teammate_id,
+                author_device_key_id=author_device_key_id,
+                created_at=created_at,
+                anchor_commit=anchor_commit,
+                constitution_digest=constitution_digest,
+            ),
+            "subject_record_id": subject_record_id.hex(),
+            "subject_digest": subject_digest.hex(),
+        }
+        canonical = canonical_constitution_bytes(signed)
+        if derive_record_id(canonical) != record_id:
+            continue
+        if not verify_constitution_record(public_key, canonical, signature):
+            continue
+        valid_endorsers.add(author_teammate_id.hex())
+    return len(valid_endorsers)
+
+
+def _valid_finalization_exists(conn, record_id: bytes) -> bool:
+    """True iff some finalization row for this proposal verifies one-hop.
+
+    Bare row presence must not be terminal: a forged merged finalization would
+    otherwise freeze the proposal ("already finalized") and report success in
+    the UI while no projections exist. There is no UNIQUE(subject_record_id)
+    on `finalization`, so invalid rows are simply ignored and a legitimate
+    finalization can be appended alongside them.
+
+    Checked per row: recomputed record_id, signature via the key-id-bound
+    device key, author == the proposal's author (the inviter-only finalization
+    rule), the author device linked to that teammate in the proposal's
+    digest-bound snapshot (an insider must not attribute their own signature
+    to the inviter -- and a legitimate finalizer's device is always in the
+    proposal snapshot, since any later device change drift-refuses the
+    proposal), and subject_digest == the recorded acceptance's commitment.
+    Deliberately NOT checked: constitution_digest equality with the proposal
+    (a legitimate finalization anchors the post-projection snapshot, which
+    always differs) and quorum re-count (re-validating against the current
+    mutable threshold would retroactively invalidate legitimate finalizations
+    when quorum is raised; auditing the signed endorsement_count claim is the
+    #167 replay's job).
+    """
+    rows = conn.execute(
+        text(
+            "SELECT record_id, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, subject_record_id, subject_digest, "
+            "endorsement_count, signature "
+            "FROM finalization WHERE subject_record_id = :sid"
+        ),
+        {"sid": record_id},
+    ).fetchall()
+    if not rows:
         return False
-    return _approval_count(conn, proposal_row[0], transcript_digest) >= _proposal_quorum(conn)
-
-
-def _proposal_steward_device_is_valid(snapshot: dict[str, object], steward_teammate_id: bytes, approver_device_key_id: bytes) -> bool:
-    steward_teammate_id_hex = steward_teammate_id.hex()
-    if steward_teammate_id_hex not in snapshot.get("stewards", []):
+    proposal_row = _load_proposal_row(conn, record_id)
+    try:
+        # The proposal row itself must verify before its author/snapshot can
+        # vouch for anything: record_id is a *stored* column, so its binding
+        # to the row's content only exists where this check runs. Without it,
+        # an in-place UPDATE (same PK, swapped author, self-consistent crafted
+        # digest+snapshot) re-roots the device binding at attacker-chosen data.
+        # Degrade to False, never raise: status display must survive tampered
+        # rows, and the fall-through (drift/awaiting) refuses conservatively.
+        _verify_proposal_row(conn, proposal_row)
+        snapshot = _verified_proposal_snapshot(proposal_row)
+    except ValueError:
         return False
-    teammate_devices = snapshot.get("teammate_devices", {})
-    if not isinstance(teammate_devices, dict):
+    author_teammate_id = proposal_row[1]
+    author_devices = set(
+        snapshot.get("teammate_devices", {}).get(author_teammate_id.hex(), [])
+    )
+    acceptance_row = _load_acceptance_row(conn, record_id)
+    if acceptance_row is None:
         return False
-    return approver_device_key_id.hex() in teammate_devices.get(steward_teammate_id_hex, [])
+    expected_subject_digest = _sha256_bytes(_acceptance_canonical_from_row(acceptance_row))
+    for (
+        fin_record_id,
+        fin_author_teammate_id,
+        fin_author_device_key_id,
+        created_at,
+        anchor_commit,
+        constitution_digest,
+        subject_record_id,
+        subject_digest,
+        endorsement_count,
+        signature,
+    ) in rows:
+        if fin_author_teammate_id != author_teammate_id:
+            continue
+        if fin_author_device_key_id.hex() not in author_devices:
+            continue
+        if subject_digest != expected_subject_digest:
+            continue
+        public_key = _device_public_key_for(conn, fin_author_device_key_id)
+        if public_key is None or key_id_from_public(public_key) != fin_author_device_key_id:
+            continue
+        signed = {
+            **_record_envelope_fields(
+                record_type="finalization",
+                author_teammate_id=fin_author_teammate_id,
+                author_device_key_id=fin_author_device_key_id,
+                created_at=created_at,
+                anchor_commit=anchor_commit,
+                constitution_digest=constitution_digest,
+            ),
+            "subject_record_id": subject_record_id.hex(),
+            "subject_digest": subject_digest.hex(),
+            "endorsement_count": endorsement_count,
+        }
+        canonical = canonical_constitution_bytes(signed)
+        if derive_record_id(canonical) != fin_record_id:
+            continue
+        if not verify_constitution_record(public_key, canonical, signature):
+            continue
+        return True
+    return False
 
 
-def _insert_steward_approval(
+def _admission_status(conn, *, record_id: bytes, constitution_digest: bytes, expires_at: str) -> str:
+    """Compute a proposal's status purely from which records/projections exist.
+
+    Never mutates: expiry and governance drift produce a computed status here,
+    and a refusal (not an UPDATE) at endorsement/finalization time.
+    """
+    # Finalized must be decided before drift: a legitimate finalization changes
+    # the constitution, so the live digest never matches the proposal's again.
+    if _valid_finalization_exists(conn, record_id):
+        return "finalized"
+    if conn.execute(
+        text("SELECT 1 FROM admission_revocation WHERE subject_record_id = :id"), {"id": record_id}
+    ).fetchone() is not None:
+        return "invalidated"
+    if expires_at < _now_iso():
+        return "expired"
+    if _constitution_digest(_constitution_snapshot(conn)) != constitution_digest:
+        return "invalidated"
+    if conn.execute(
+        text("SELECT 1 FROM admission_acceptance WHERE subject_record_id = :id"), {"id": record_id}
+    ).fetchone() is not None:
+        return "awaiting_quorum"
+    return "awaiting_invitee"
+
+
+def _admission_action_block_reason(conn, proposal_row) -> str | None:
+    """Reason a pending action (endorse/finalize/accept) must be refused, or None."""
+    record_id, constitution_digest, expires_at = proposal_row[0], proposal_row[5], proposal_row[11]
+    status = _admission_status(
+        conn, record_id=record_id, constitution_digest=constitution_digest, expires_at=expires_at
+    )
+    if status == "finalized":
+        return "Proposal is already finalized"
+    if status == "expired":
+        return "Proposal has expired"
+    if status == "invalidated":
+        if conn.execute(
+            text("SELECT 1 FROM admission_revocation WHERE subject_record_id = :id"),
+            {"id": record_id},
+        ).fetchone() is not None:
+            return "Proposal has been revoked"
+        return "Proposal invalidated by governance drift"
+    return None
+
+
+def _snapshot_core_integrator_devices(conn, snapshot: dict) -> dict[str, set[str]]:
+    """Teammates who are automatic (read-write) on Core in `snapshot`, mapped to
+    their linked device key ids -- the current authority to endorse admission.
+    """
+    core_berth_id = _core_berth_id(conn)
+    core_hex = core_berth_id.hex() if core_berth_id is not None else None
+    devices = snapshot.get("teammate_devices", {})
+    integrators: dict[str, set[str]] = {}
+    for entry in snapshot.get("berth_roles", []):
+        if entry.get("berth_id") == core_hex and entry.get("role") == "read-write":
+            teammate_hex = entry.get("teammate_id")
+            integrators[teammate_hex] = set(devices.get(teammate_hex, []))
+    return integrators
+
+
+def _append_endorsement(
     conn,
     *,
-    proposal_id: bytes,
-    steward_teammate_id: bytes,
-    approver_device_key_id: bytes,
-    signature: bytes,
-    transcript_digest: bytes,
+    proposal_row,
+    endorser_teammate_id: bytes,
+    author_private_key: bytes,
+    author_public_key: bytes,
+    anchor_commit: str | None,
 ) -> None:
+    acceptance_row = _load_acceptance_row(conn, proposal_row[0])
+    if acceptance_row is None:
+        raise ValueError("Proposal does not have a recorded acceptance yet")
+    subject_digest = _sha256_bytes(_acceptance_canonical_from_row(acceptance_row))
+    author_device_key_id = key_id_from_public(author_public_key)
+    snapshot = _constitution_snapshot(conn)
+    digest = _constitution_digest(snapshot)
+    now = _now_iso()
+    envelope = _record_envelope_fields(
+        record_type="endorsement",
+        author_teammate_id=endorser_teammate_id,
+        author_device_key_id=author_device_key_id,
+        created_at=now,
+        anchor_commit=anchor_commit,
+        constitution_digest=digest,
+    )
+    signed = {
+        **envelope,
+        "subject_record_id": proposal_row[0].hex(),
+        "subject_digest": subject_digest.hex(),
+    }
+    canonical = canonical_constitution_bytes(signed)
+    record_id = derive_record_id(canonical)
+    signature = sign_constitution_record(author_private_key, canonical)
+    # OR IGNORE enforces the per-endorsing-teammate UNIQUE constraint: a steward's
+    # two linked devices, or a repeated endorsement, count once.
     conn.execute(
         text(
-            "INSERT OR REPLACE INTO steward_approval "
-            "(approval_id, proposal_id, steward_teammate_id, approver_device_key_id, "
-            "transcript_digest, signature, created_at) "
-            "VALUES (:approval_id, :proposal_id, :steward_teammate_id, :approver_device_key_id, "
-            ":transcript_digest, :signature, :created_at)"
+            "INSERT OR IGNORE INTO endorsement ("
+            "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+            "subject_record_id, subject_digest, signature) VALUES ("
+            ":record_id, 'endorsement', :author_teammate_id, :author_device_key_id, :created_at, "
+            ":anchor_commit, :constitution_digest, :constitution_snapshot_json, 1, "
+            ":subject_record_id, :subject_digest, :signature)"
         ),
         {
-            "approval_id": uuid7(),
-            "proposal_id": proposal_id,
-            "steward_teammate_id": steward_teammate_id,
-            "approver_device_key_id": approver_device_key_id,
-            "transcript_digest": transcript_digest,
+            "record_id": record_id,
+            "author_teammate_id": endorser_teammate_id,
+            "author_device_key_id": author_device_key_id,
+            "created_at": now,
+            "anchor_commit": anchor_commit,
+            "constitution_digest": digest,
+            "constitution_snapshot_json": _json_dumps_sorted(snapshot),
+            "subject_record_id": proposal_row[0],
+            "subject_digest": subject_digest,
             "signature": signature,
-            "created_at": _now_iso(),
         },
     )
+
+
+def _append_finalization(
+    conn,
+    *,
+    proposal_row,
+    finalizer_teammate_id: bytes,
+    author_private_key: bytes,
+    author_public_key: bytes,
+    anchor_commit: str | None,
+    endorsement_count: int,
+) -> None:
+    acceptance_row = _load_acceptance_row(conn, proposal_row[0])
+    if acceptance_row is None:
+        raise ValueError("Proposal does not have a recorded acceptance yet")
+    subject_digest = _sha256_bytes(_acceptance_canonical_from_row(acceptance_row))
+    author_device_key_id = key_id_from_public(author_public_key)
+    snapshot = _constitution_snapshot(conn)
+    digest = _constitution_digest(snapshot)
+    now = _now_iso()
+    envelope = _record_envelope_fields(
+        record_type="finalization",
+        author_teammate_id=finalizer_teammate_id,
+        author_device_key_id=author_device_key_id,
+        created_at=now,
+        anchor_commit=anchor_commit,
+        constitution_digest=digest,
+    )
+    signed = {
+        **envelope,
+        "subject_record_id": proposal_row[0].hex(),
+        "subject_digest": subject_digest.hex(),
+        "endorsement_count": endorsement_count,
+    }
+    canonical = canonical_constitution_bytes(signed)
+    record_id = derive_record_id(canonical)
+    signature = sign_constitution_record(author_private_key, canonical)
+    conn.execute(
+        text(
+            "INSERT INTO finalization ("
+            "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+            "subject_record_id, subject_digest, endorsement_count, signature) VALUES ("
+            ":record_id, 'finalization', :author_teammate_id, :author_device_key_id, :created_at, "
+            ":anchor_commit, :constitution_digest, :constitution_snapshot_json, 1, "
+            ":subject_record_id, :subject_digest, :endorsement_count, :signature)"
+        ),
+        {
+            "record_id": record_id,
+            "author_teammate_id": finalizer_teammate_id,
+            "author_device_key_id": author_device_key_id,
+            "created_at": now,
+            "anchor_commit": anchor_commit,
+            "constitution_digest": digest,
+            "constitution_snapshot_json": _json_dumps_sorted(snapshot),
+            "subject_record_id": proposal_row[0],
+            "subject_digest": subject_digest,
+            "endorsement_count": endorsement_count,
+            "signature": signature,
+        },
+    )
+
+
+def _expand_mode_plan_at_finalization(
+    conn,
+    *,
+    proposal_row,
+    invitee_teammate_id: bytes,
+    author_teammate_id: bytes,
+    author_private_key: bytes,
+    author_public_key: bytes,
+    anchor_commit: str | None,
+) -> None:
+    """One signed integration_mode_change per berth for the invitee, expanding
+    the proposal's signed mode_plan (core_mode for Core, other_mode elsewhere).
+    Each record also writes its berth_role projection.
+
+    No default plan: a missing or malformed plan refuses finalization rather
+    than silently granting the steward (most privileged) expansion. Callers
+    have already run _verify_proposal_row, so this only backstops it.
+    """
+    if not proposal_row[14]:
+        raise ValueError("Proposal has no mode plan")
+    plan = json.loads(proposal_row[14])
+    _validate_mode_plan(plan)
+    core_mode = plan["core_mode"]
+    other_mode = plan["other_mode"]
+    core_berth_id = _core_berth_id(conn)
+    for (berth_id,) in conn.execute(text("SELECT id FROM team_app_berth")).fetchall():
+        mode = core_mode if berth_id == core_berth_id else other_mode
+        _append_integration_mode_change(
+            conn,
+            author_teammate_id=author_teammate_id,
+            author_private_key=author_private_key,
+            author_public_key=author_public_key,
+            teammate_id=invitee_teammate_id,
+            berth_id=berth_id,
+            mode=mode,
+            anchor_commit=anchor_commit,
+        )
 
 
 def _upsert_teammate_row(
@@ -1647,7 +2077,7 @@ class TeamDevice(Base):
 
 # ---- Constants ----
 
-USER_SCHEMA_VERSION = 62
+USER_SCHEMA_VERSION = 64
 
 
 # ---- Provisioning functions ----
@@ -3765,10 +4195,10 @@ def _role_value_for_mode(mode: str) -> str:
 
 
 def _constitution_snapshot(conn) -> dict[str, object]:
-    """Generalizes `_governance_snapshot` beyond Core stewards to every berth's
-    current integration mode, since Constitution record types besides
-    admission anchor against the full membership/device/mode picture rather
-    than just the Core steward roster.
+    """The interim anchor snapshot shared by every Constitution record type:
+    the full membership/device/berth-role picture (teammates, their devices,
+    and every berth role), not just the Core steward roster. Admission's Core
+    integrator authority is derived from its `berth_roles` entries.
     """
     teammate_ids = [
         row[0].hex() for row in conn.execute(text("SELECT id FROM teammate ORDER BY id")).fetchall()
@@ -3857,81 +4287,17 @@ def set_teammate_integration_mode(
                     "(read-write) standing on that berth"
                 )
 
-            snapshot = _constitution_snapshot(conn)
-            digest = _constitution_digest(snapshot)
-            now = _now_iso()
-            new_role = _role_value_for_mode(mode)
             anchor_commit = _team_head_commit(team_sync_dir)
-
-            signed_fields = {
-                "record_type": "integration_mode_change",
-                "author_teammate_id": self_in_team.hex(),
-                "author_device_key_id": author_device_key_id.hex(),
-                "created_at": now,
-                "anchor_commit": anchor_commit,
-                "constitution_digest": digest.hex(),
-                "schema_version": 1,
-                "teammate_id": teammate_id.hex(),
-                "berth_id": berth_id.hex(),
-                "mode": mode,
-            }
-            canonical = canonical_constitution_bytes(signed_fields)
-            record_id = derive_record_id(canonical)
-            signature = sign_constitution_record(author_private_key, canonical)
-
-            conn.execute(
-                text(
-                    "INSERT INTO integration_mode_change ("
-                    "record_id, record_type, author_teammate_id, author_device_key_id, "
-                    "created_at, anchor_commit, constitution_digest, constitution_snapshot_json, "
-                    "schema_version, teammate_id, berth_id, mode, signature"
-                    ") VALUES ("
-                    ":record_id, :record_type, :author_teammate_id, :author_device_key_id, "
-                    ":created_at, :anchor_commit, :constitution_digest, :constitution_snapshot_json, "
-                    ":schema_version, :teammate_id, :berth_id, :mode, :signature"
-                    ")"
-                ),
-                {
-                    "record_id": record_id,
-                    "record_type": "integration_mode_change",
-                    "author_teammate_id": self_in_team,
-                    "author_device_key_id": author_device_key_id,
-                    "created_at": now,
-                    "anchor_commit": anchor_commit,
-                    "constitution_digest": digest,
-                    "constitution_snapshot_json": _json_dumps_sorted(snapshot),
-                    "schema_version": 1,
-                    "teammate_id": teammate_id,
-                    "berth_id": berth_id,
-                    "mode": mode,
-                    "signature": signature,
-                },
+            record_id = _append_integration_mode_change(
+                conn,
+                author_teammate_id=self_in_team,
+                author_private_key=author_private_key,
+                author_public_key=author_public_key,
+                teammate_id=teammate_id,
+                berth_id=berth_id,
+                mode=mode,
+                anchor_commit=anchor_commit,
             )
-
-            existing_role_row = conn.execute(
-                text(
-                    "SELECT id FROM berth_role WHERE teammate_id = :teammate_id AND berth_id = :berth_id"
-                ),
-                {"teammate_id": teammate_id, "berth_id": berth_id},
-            ).fetchone()
-            if existing_role_row is None:
-                conn.execute(
-                    text(
-                        "INSERT INTO berth_role (id, teammate_id, berth_id, role) "
-                        "VALUES (:id, :teammate_id, :berth_id, :role)"
-                    ),
-                    {
-                        "id": uuid7(),
-                        "teammate_id": teammate_id,
-                        "berth_id": berth_id,
-                        "role": new_role,
-                    },
-                )
-            else:
-                conn.execute(
-                    text("UPDATE berth_role SET role = :role WHERE id = :id"),
-                    {"role": new_role, "id": existing_role_row[0]},
-                )
     finally:
         engine.dispose()
 
@@ -3939,6 +4305,102 @@ def set_teammate_integration_mode(
     repo.stage(["core.db"])
     repo.commit(f"Set integration mode for teammate {teammate_id.hex()} on berth {berth_id.hex()}")
 
+    return record_id
+
+
+def _append_integration_mode_change(
+    conn,
+    *,
+    author_teammate_id: bytes,
+    author_private_key: bytes,
+    author_public_key: bytes,
+    teammate_id: bytes,
+    berth_id: bytes,
+    mode: str,
+    anchor_commit: str | None,
+) -> bytes:
+    """Record-construction core shared by `set_teammate_integration_mode` and
+    admission finalization: build/sign the record, insert it, and update the
+    `berth_role` projection. Authorization (cert trust, author standing) is the
+    caller's responsibility.
+    """
+    if mode not in ("automatic", "proposal-only"):
+        raise ValueError(f"Unknown integration mode: {mode!r}")
+    author_device_key_id = key_id_from_public(author_public_key)
+    snapshot = _constitution_snapshot(conn)
+    digest = _constitution_digest(snapshot)
+    now = _now_iso()
+    new_role = _role_value_for_mode(mode)
+
+    signed_fields = {
+        "record_type": "integration_mode_change",
+        "author_teammate_id": author_teammate_id.hex(),
+        "author_device_key_id": author_device_key_id.hex(),
+        "created_at": now,
+        "anchor_commit": anchor_commit,
+        "constitution_digest": digest.hex(),
+        "schema_version": 1,
+        "teammate_id": teammate_id.hex(),
+        "berth_id": berth_id.hex(),
+        "mode": mode,
+    }
+    canonical = canonical_constitution_bytes(signed_fields)
+    record_id = derive_record_id(canonical)
+    signature = sign_constitution_record(author_private_key, canonical)
+
+    conn.execute(
+        text(
+            "INSERT INTO integration_mode_change ("
+            "record_id, record_type, author_teammate_id, author_device_key_id, "
+            "created_at, anchor_commit, constitution_digest, constitution_snapshot_json, "
+            "schema_version, teammate_id, berth_id, mode, signature"
+            ") VALUES ("
+            ":record_id, :record_type, :author_teammate_id, :author_device_key_id, "
+            ":created_at, :anchor_commit, :constitution_digest, :constitution_snapshot_json, "
+            ":schema_version, :teammate_id, :berth_id, :mode, :signature"
+            ")"
+        ),
+        {
+            "record_id": record_id,
+            "record_type": "integration_mode_change",
+            "author_teammate_id": author_teammate_id,
+            "author_device_key_id": author_device_key_id,
+            "created_at": now,
+            "anchor_commit": anchor_commit,
+            "constitution_digest": digest,
+            "constitution_snapshot_json": _json_dumps_sorted(snapshot),
+            "schema_version": 1,
+            "teammate_id": teammate_id,
+            "berth_id": berth_id,
+            "mode": mode,
+            "signature": signature,
+        },
+    )
+
+    existing_role_row = conn.execute(
+        text(
+            "SELECT id FROM berth_role WHERE teammate_id = :teammate_id AND berth_id = :berth_id"
+        ),
+        {"teammate_id": teammate_id, "berth_id": berth_id},
+    ).fetchone()
+    if existing_role_row is None:
+        conn.execute(
+            text(
+                "INSERT INTO berth_role (id, teammate_id, berth_id, role) "
+                "VALUES (:id, :teammate_id, :berth_id, :role)"
+            ),
+            {
+                "id": uuid7(),
+                "teammate_id": teammate_id,
+                "berth_id": berth_id,
+                "role": new_role,
+            },
+        )
+    else:
+        conn.execute(
+            text("UPDATE berth_role SET role = :role WHERE id = :id"),
+            {"role": new_role, "id": existing_role_row[0]},
+        )
     return record_id
 
 
@@ -4396,10 +4858,19 @@ def activate_app_for_team(root_dir, participant_hex, team_name, app_name):
 
 
 def create_invitation(
-    root_dir, participant_hex, team_name, inviter_cloud=None, invitee_label=None, role="steward"
+    root_dir, participant_hex, team_name, inviter_cloud=None, invitee_label=None, mode_plan=None
 ):
-    """Create a transcript-bound admission proposal token for a team."""
-    _role_to_core_berth_role(role)
+    """Create a signed append-only `admission_proposal` record and its token.
+
+    `mode_plan` is the per-berth starting-mode expansion rule
+    ({"core_mode": ..., "other_mode": ...}); callers translate the UI's
+    steward/contributor preset at the boundary. Defaults to the steward plan.
+    The plan is signed into the proposal's canonical bytes: it determines the
+    authority granted at finalization, so it must carry the inviter's signature.
+    """
+    if mode_plan is None:
+        mode_plan = mode_plan_for_preset("steward")
+    _validate_mode_plan(mode_plan)
     root_dir = pathlib.Path(root_dir)
     participant_dir = root_dir / "Participants" / participant_hex
 
@@ -4424,9 +4895,10 @@ def create_invitation(
     )
     if inviter_sender_key is None:
         raise ValueError(f"No sender key found for team '{team_name}'")
-    _inviter_private_key, _inviter_device_public_key = get_current_team_device_key(
+    inviter_private_key, inviter_device_public_key = get_current_team_device_key(
         root_dir, participant_hex, team_name
     )
+    inviter_device_key_id = key_id_from_public(inviter_device_public_key)
 
     inviter_core_cloud = _core_cloud_allocation_or_raise(
         root_dir, participant_hex, team_name
@@ -4438,7 +4910,6 @@ def create_invitation(
         ):
             raise ValueError("inviter_cloud does not match the Core cloud allocation")
 
-    proposal_id = uuid7()
     invitee_teammate_id = uuid7()
     nonce = secrets.token_bytes(16)
     now_dt = datetime.now(timezone.utc)
@@ -4449,36 +4920,66 @@ def create_invitation(
         if quorum < 1:
             raise ValueError("Admission quorum must be at least 1")
         anchor_commit = _team_head_commit(team_sync_dir)
-        governance_snapshot = _governance_snapshot(conn)
-        governance_digest = _governance_digest(governance_snapshot)
+        snapshot = _constitution_snapshot(conn)
+        digest = _constitution_digest(snapshot)
+        expires_at = _proposal_expiry(now_dt, expiry_seconds)
+
+        # The proposal record is signed at creation and so cannot embed the
+        # invitee's device key (it does not exist until acceptance); the
+        # separable label payload is excluded from the signed bytes (only the
+        # -- here unpopulated -- label commitment would be signed).
+        signed_fields = {
+            **_record_envelope_fields(
+                record_type="admission_proposal",
+                author_teammate_id=inviter_teammate_id,
+                author_device_key_id=inviter_device_key_id,
+                created_at=now,
+                anchor_commit=anchor_commit,
+                constitution_digest=digest,
+            ),
+            "nonce": nonce.hex(),
+            "team_id": team_id.hex(),
+            "invitee_teammate_id": invitee_teammate_id.hex(),
+            "invitee_label_commitment": None,
+            "expires_at": expires_at,
+            "mode_plan": mode_plan,
+        }
+        canonical = canonical_constitution_bytes(signed_fields)
+        proposal_id = derive_record_id(canonical)
+        signature = sign_constitution_record(inviter_private_key, canonical)
+
         conn.execute(
             text(
                 "INSERT INTO admission_proposal ("
-                "proposal_id, nonce, team_id, inviter_teammate_id, invitee_teammate_id, "
-                "invitee_label, role, anchor_commit, governance_digest, governance_snapshot_json, "
-                "state, created_at, expires_at"
+                "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+                "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+                "nonce, team_id, invitee_teammate_id, invitee_label_commitment, expires_at, "
+                "signature, invitee_label_payload, mode_plan"
                 ") VALUES ("
-                ":proposal_id, :nonce, :team_id, :inviter_teammate_id, :invitee_teammate_id, "
-                ":invitee_label, :role, :anchor_commit, :governance_digest, :governance_snapshot_json, "
-                "'awaiting_invitee', :created_at, :expires_at)"
+                ":record_id, 'admission_proposal', :author_teammate_id, :author_device_key_id, :created_at, "
+                ":anchor_commit, :constitution_digest, :constitution_snapshot_json, 1, "
+                ":nonce, :team_id, :invitee_teammate_id, NULL, :expires_at, "
+                ":signature, :invitee_label_payload, :mode_plan)"
             ),
             {
-                "proposal_id": proposal_id,
+                "record_id": proposal_id,
+                "author_teammate_id": inviter_teammate_id,
+                "author_device_key_id": inviter_device_key_id,
+                "created_at": now,
+                "anchor_commit": anchor_commit,
+                "constitution_digest": digest,
+                "constitution_snapshot_json": _json_dumps_sorted(snapshot),
                 "nonce": nonce,
                 "team_id": team_id,
-                "inviter_teammate_id": inviter_teammate_id,
                 "invitee_teammate_id": invitee_teammate_id,
-                "invitee_label": invitee_label,
-                "role": role,
-                "anchor_commit": anchor_commit,
-                "governance_digest": governance_digest,
-                "governance_snapshot_json": _json_dumps_sorted(governance_snapshot),
-                "created_at": now,
-                "expires_at": _proposal_expiry(now_dt, expiry_seconds),
+                "expires_at": expires_at,
+                "signature": signature,
+                "invitee_label_payload": invitee_label,
+                "mode_plan": _json_dumps_sorted(mode_plan),
             },
         )
 
-    # Build token with only the material the invitee needs for transcript-bound admission.
+    # Build token with only the material the invitee needs to author acceptance.
     token_data = {
         "proposal_id": proposal_id.hex(),
         "invitation_id": proposal_id.hex(),
@@ -4489,7 +4990,6 @@ def create_invitation(
         "invitee_teammate_id": invitee_teammate_id.hex(),
         "inviter_display_name": inviter_display_name,
         "invitee_label": invitee_label,
-        "role": role,
         "inviter_cloud": {
             "protocol": inviter_core_cloud["protocol"],
             "url": inviter_core_cloud["url"],
@@ -4647,32 +5147,43 @@ def accept_invitation(
     with attached_note_to_self_connection(root_dir, acceptor_participant_hex) as conn:
         device_row = _current_device_row(conn)
         invitee_bootstrap_key = device_row[1]
-    transcript_payload = _proposal_transcript_payload(
-        proposal_id=proposal_id,
+
+    # Build the complete signed `admission_acceptance` record invitee-side. The
+    # inviter transports and inserts it verbatim after a self-certifying verify.
+    device_public_key = team_keys["device_key"].public_key
+    now = _now_iso()
+    acceptance_signed_fields = _acceptance_signed_fields(
+        envelope=_record_envelope_fields(
+            record_type="admission_acceptance",
+            author_teammate_id=acceptor_teammate_id,
+            author_device_key_id=acceptor_device_key_id,
+            created_at=now,
+            anchor_commit=None,
+            constitution_digest=None,
+        ),
+        subject_record_id=proposal_id,
         nonce=nonce,
-        team_id=team_id,
-        invitee_teammate_id=acceptor_teammate_id,
-        invitee_device_public_key=team_keys["device_key"].public_key,
+        invitee_device_public_key=device_public_key,
         invitee_bootstrap_key=invitee_bootstrap_key,
     )
-    acceptance_signature = _sign_bytes(
-        team_keys["device_private_key"],
-        _json_bytes(transcript_payload),
+    acceptance_canonical = canonical_constitution_bytes(acceptance_signed_fields)
+    acceptance_record_id = derive_record_id(acceptance_canonical)
+    acceptance_signature = sign_constitution_record(
+        team_keys["device_private_key"], acceptance_canonical
     )
 
     acceptance_data = {
-        "proposal_id": proposal_id.hex(),
-        "invitation_id": proposal_id.hex(),
+        "record_id": acceptance_record_id.hex(),
+        "record_type": "admission_acceptance",
+        "author_teammate_id": acceptor_teammate_id.hex(),
+        "author_device_key_id": acceptor_device_key_id.hex(),
+        "created_at": now,
+        "subject_record_id": proposal_id.hex(),
         "nonce": nonce.hex(),
         "team_id": team_id.hex(),
-        "invitee_teammate_id": acceptor_teammate_id.hex(),
-        "acceptor_teammate_id": acceptor_teammate_id.hex(),
-        "invitee_device_key_id": acceptor_device_key_id.hex(),
-        "acceptor_device_key_id": acceptor_device_key_id.hex(),
-        "invitee_device_public_key": team_keys["device_key"].public_key.hex(),
-        "acceptor_device_public_key": team_keys["device_key"].public_key.hex(),
+        "invitee_device_public_key": device_public_key.hex(),
         "invitee_bootstrap_key": invitee_bootstrap_key.hex(),
-        "acceptance_signature": acceptance_signature.hex(),
+        "signature": acceptance_signature.hex(),
     }
     return _tokenize(acceptance_data)
 
@@ -4680,23 +5191,59 @@ def accept_invitation(
 def complete_invitation_acceptance(
     root_dir, participant_hex, team_name, acceptance_b64
 ):
-    """Record acceptance and finalize immediately when quorum is met."""
+    """Insert the invitee's signed acceptance record, append the inviter's
+    endorsement, and finalize inline when quorum is met.
+
+    The inviter transports the invitee-authored `admission_acceptance` record
+    and inserts it verbatim after a self-certifying verify -- the invitee is
+    the author, the inviter is only the courier.
+    """
     root_dir = pathlib.Path(root_dir)
     participant_dir = root_dir / "Participants" / participant_hex
 
     acceptance = _untokenize(acceptance_b64)
-    proposal_id = bytes.fromhex(acceptance["proposal_id"])
+    acceptance_record_id = bytes.fromhex(acceptance["record_id"])
+    invitee_teammate_id = bytes.fromhex(acceptance["author_teammate_id"])
+    author_device_key_id = bytes.fromhex(acceptance["author_device_key_id"])
+    created_at = acceptance["created_at"]
+    proposal_id = bytes.fromhex(acceptance["subject_record_id"])
     nonce = bytes.fromhex(acceptance["nonce"])
     team_id = bytes.fromhex(acceptance["team_id"])
-    invitee_teammate_id = bytes.fromhex(acceptance["invitee_teammate_id"])
-    invitee_device_key_id = bytes.fromhex(acceptance["invitee_device_key_id"])
     invitee_device_public_key = bytes.fromhex(acceptance["invitee_device_public_key"])
     invitee_bootstrap_key = bytes.fromhex(acceptance["invitee_bootstrap_key"])
-    acceptance_signature = bytes.fromhex(acceptance["acceptance_signature"])
+    acceptance_signature = bytes.fromhex(acceptance["signature"])
+
+    # Self-certifying verify: recompute canonical bytes, verify the signature
+    # against the *embedded* device key, and require author_device_key_id to be
+    # that key's id and record_id to match the contents.
+    acceptance_signed_fields = _acceptance_signed_fields(
+        envelope=_record_envelope_fields(
+            record_type=acceptance["record_type"],
+            author_teammate_id=invitee_teammate_id,
+            author_device_key_id=author_device_key_id,
+            created_at=created_at,
+            anchor_commit=None,
+            constitution_digest=None,
+        ),
+        subject_record_id=proposal_id,
+        nonce=nonce,
+        invitee_device_public_key=invitee_device_public_key,
+        invitee_bootstrap_key=invitee_bootstrap_key,
+    )
+    acceptance_canonical = canonical_constitution_bytes(acceptance_signed_fields)
+    if key_id_from_public(invitee_device_public_key) != author_device_key_id:
+        raise ValueError("Acceptance author_device_key_id does not match its embedded device key")
+    if derive_record_id(acceptance_canonical) != acceptance_record_id:
+        raise ValueError("Acceptance record_id does not match its contents")
+    if not verify_constitution_record(
+        invitee_device_public_key, acceptance_canonical, acceptance_signature
+    ):
+        raise ValueError("Acceptance signature is invalid")
 
     team_db_path = participant_dir / team_name / "Sync" / "core.db"
     ensure_team_db_schema(team_db_path)
     engine = _sqlite_engine(team_db_path)
+    team_sync_dir = participant_dir / team_name / "Sync"
     inviter_private_key, inviter_public_key = get_current_team_device_key(
         root_dir, participant_hex, team_name
     )
@@ -4739,155 +5286,122 @@ def complete_invitation_acceptance(
 
     failure_reason = None
     with engine.begin() as conn:
-        proposal_row = _load_admission_proposal_row(conn, proposal_id)
-        ok, reason = _proposal_is_still_valid(conn, proposal_row)
-        if not ok:
-            failure_reason = reason
-        elif proposal_row[10] != "awaiting_invitee":
-            raise ValueError(f"Proposal is not awaiting invitee acceptance (state: {proposal_row[10]})")
-        elif proposal_row[1] != nonce:
-            raise ValueError("Nonce mismatch")
-        elif proposal_row[2] != team_id:
+        proposal_row = _load_proposal_row(conn, proposal_id)
+        block_reason = _admission_action_block_reason(conn, proposal_row)
+        if block_reason is not None:
+            failure_reason = block_reason
+        elif _load_acceptance_row(conn, proposal_id) is not None:
+            raise ValueError("Proposal already has a recorded acceptance")
+        elif proposal_row[7] != nonce:
+            raise ValueError("Acceptance nonce does not match proposal")
+        elif proposal_row[8] != team_id:
             raise ValueError("Acceptance team_id does not match proposal")
-        elif proposal_row[4] != invitee_teammate_id:
+        elif proposal_row[9] != invitee_teammate_id:
             raise ValueError("Acceptance teammate_id does not match proposal")
         else:
-            transcript_payload = _proposal_transcript_payload(
-                proposal_id=proposal_id,
-                nonce=nonce,
-                team_id=team_id,
-                invitee_teammate_id=invitee_teammate_id,
-                invitee_device_public_key=invitee_device_public_key,
-                invitee_bootstrap_key=invitee_bootstrap_key,
-            )
-            if key_id_from_public(invitee_device_public_key) != invitee_device_key_id:
-                raise ValueError("Acceptance device_key_id does not match invitee public key")
-            if not _verify_signature(
-                invitee_device_public_key,
-                _json_bytes(transcript_payload),
-                acceptance_signature,
-            ):
-                raise ValueError("Acceptance signature is invalid")
-
-            transcript_digest = _proposal_transcript_digest(transcript_payload)
-            now = _now_iso()
-            quorum = _proposal_quorum(conn)
+            # The stored proposal may have been altered by a merge since
+            # creation; re-verify it before endorsing/finalizing against it
+            # (this is what binds the signed mode_plan).
+            _verify_proposal_row(conn, proposal_row)
+            anchor_commit = _team_head_commit(team_sync_dir)
             conn.execute(
                 text(
-                    "UPDATE admission_proposal SET "
-                    "state = :state, acceptance_recorded_at = :acceptance_recorded_at, "
-                    "invitee_device_public_key = :invitee_device_public_key, "
-                    "invitee_bootstrap_key = :invitee_bootstrap_key, "
-                    "acceptance_signature = :acceptance_signature, "
-                    "transcript_digest = :transcript_digest, transcript_json = :transcript_json "
-                    "WHERE proposal_id = :proposal_id"
+                    "INSERT INTO admission_acceptance ("
+                    "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+                    "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+                    "subject_record_id, nonce, invitee_device_public_key, invitee_bootstrap_key, signature"
+                    ") VALUES ("
+                    ":record_id, 'admission_acceptance', :author_teammate_id, :author_device_key_id, "
+                    ":created_at, NULL, NULL, NULL, 1, "
+                    ":subject_record_id, :nonce, :invitee_device_public_key, :invitee_bootstrap_key, :signature)"
                 ),
                 {
-                    "proposal_id": proposal_id,
-                    "state": "awaiting_quorum" if quorum > 1 else "awaiting_invitee",
-                    "acceptance_recorded_at": now,
+                    "record_id": acceptance_record_id,
+                    "author_teammate_id": invitee_teammate_id,
+                    "author_device_key_id": author_device_key_id,
+                    "created_at": created_at,
+                    "subject_record_id": proposal_id,
+                    "nonce": nonce,
                     "invitee_device_public_key": invitee_device_public_key,
                     "invitee_bootstrap_key": invitee_bootstrap_key,
-                    "acceptance_signature": acceptance_signature,
-                    "transcript_digest": transcript_digest,
-                    "transcript_json": _json_dumps_sorted(transcript_payload),
+                    "signature": acceptance_signature,
                 },
             )
-            approval_signature = _sign_bytes(
-                inviter_private_key,
-                _approval_payload(
-                    proposal_id=proposal_id,
-                    transcript_digest=transcript_digest,
-                    steward_teammate_id=inviter_teammate_id,
-                ),
-            )
-            _insert_steward_approval(
-                conn,
-                proposal_id=proposal_id,
-                steward_teammate_id=inviter_teammate_id,
-                approver_device_key_id=key_id_from_public(inviter_public_key),
-                signature=approval_signature,
-                transcript_digest=transcript_digest,
-            )
 
-            refreshed_row = _load_admission_proposal_row(conn, proposal_id)
-            if _proposal_has_quorum(conn, refreshed_row):
-                _upsert_teammate_row(conn, invitee_teammate_id, display_name=proposal_row[5])
+            # The inviter endorses the acceptance they just recorded -- but
+            # only if they are an eligible endorser (automatic Core integrator
+            # in the proposal's snapshot); an ineligible inviter must not
+            # author an endorsement that _count_valid_endorsements would
+            # rightly refuse to count.
+            snapshot = _verified_proposal_snapshot(proposal_row)
+            integrators = _snapshot_core_integrator_devices(conn, snapshot)
+            inviter_device_key_id = key_id_from_public(inviter_public_key)
+            if inviter_device_key_id.hex() in integrators.get(
+                inviter_teammate_id.hex(), set()
+            ):
+                _append_endorsement(
+                    conn,
+                    proposal_row=proposal_row,
+                    endorser_teammate_id=inviter_teammate_id,
+                    author_private_key=inviter_private_key,
+                    author_public_key=inviter_public_key,
+                    anchor_commit=anchor_commit,
+                )
+
+            acceptance_row = _load_acceptance_row(conn, proposal_id)
+            endorsement_count = _count_valid_endorsements(conn, proposal_row, acceptance_row)
+            if endorsement_count >= _proposal_quorum(conn):
+                _upsert_teammate_row(conn, invitee_teammate_id, display_name=proposal_row[13])
                 _store_team_certificate(conn, membership_cert, issuer_teammate_id=inviter_teammate_id)
                 stored_device_key_id = _upsert_team_device_row(
-                    conn,
-                    invitee_teammate_id,
-                    invitee_device_public_key,
+                    conn, invitee_teammate_id, invitee_device_public_key
                 )
-                if stored_device_key_id != invitee_device_key_id:
+                if stored_device_key_id != author_device_key_id:
                     raise ValueError("Acceptance device_key_id does not match invitee public key")
-
-                berth_rows = conn.execute(text("SELECT id FROM team_app_berth")).fetchall()
-                core_role = _role_to_core_berth_role(proposal_row[6])
-                for berth_row in berth_rows:
-                    conn.execute(
-                        text(
-                            "INSERT INTO berth_role (id, teammate_id, berth_id, role) "
-                            "VALUES (:id, :teammate_id, :berth_id, :role)"
-                        ),
-                        {
-                            "id": uuid7(),
-                            "teammate_id": invitee_teammate_id,
-                            "berth_id": berth_row[0],
-                            "role": core_role,
-                        },
-                    )
-                finalization_signature = _sign_bytes(
-                    inviter_private_key,
-                    _finalization_payload(
-                        proposal_id=proposal_id,
-                        transcript_digest=transcript_digest,
-                        invitee_teammate_id=invitee_teammate_id,
-                    ),
+                _append_finalization(
+                    conn,
+                    proposal_row=proposal_row,
+                    finalizer_teammate_id=inviter_teammate_id,
+                    author_private_key=inviter_private_key,
+                    author_public_key=inviter_public_key,
+                    anchor_commit=anchor_commit,
+                    endorsement_count=endorsement_count,
                 )
-                conn.execute(
-                    text(
-                        "UPDATE admission_proposal SET state = 'finalized', "
-                        "finalized_at = :finalized_at, finalization_signature = :finalization_signature "
-                        "WHERE proposal_id = :proposal_id"
-                    ),
-                    {
-                        "proposal_id": proposal_id,
-                        "finalized_at": now,
-                        "finalization_signature": finalization_signature,
-                    },
-                )
-            else:
-                conn.execute(
-                    text(
-                        "UPDATE admission_proposal SET state = 'awaiting_quorum' "
-                        "WHERE proposal_id = :proposal_id"
-                    ),
-                    {"proposal_id": proposal_id},
+                _expand_mode_plan_at_finalization(
+                    conn,
+                    proposal_row=proposal_row,
+                    invitee_teammate_id=invitee_teammate_id,
+                    author_teammate_id=inviter_teammate_id,
+                    author_private_key=inviter_private_key,
+                    author_public_key=inviter_public_key,
+                    anchor_commit=anchor_commit,
                 )
 
     engine.dispose()
     if failure_reason is not None:
         raise ValueError(failure_reason)
 
-    team_sync_dir = participant_dir / team_name / "Sync"
     repo = _Repo(team_sync_dir / ".git", team_sync_dir)
     repo.stage(["core.db"])
     repo.commit("Recorded admission acceptance")
 
 
-def sign_steward_approval(root_dir, participant_hex, team_name, proposal_id_hex):
+def endorse_admission(root_dir, participant_hex, team_name, proposal_id_hex):
+    """Append this teammate's `endorsement` of an admission proposal's acceptance.
+
+    Authorized only for a current automatic Core integrator (UI "steward") whose
+    signing device is linked, checked against the proposal's anchored snapshot.
+    """
     root_dir = pathlib.Path(root_dir)
     proposal_id = bytes.fromhex(proposal_id_hex)
     team_db_path = _team_db_path(root_dir, participant_hex, team_name)
     ensure_team_db_schema(team_db_path)
     engine = _sqlite_engine(team_db_path)
-    approver_private_key, approver_public_key = get_current_team_device_key(
-        root_dir,
-        participant_hex,
-        team_name,
+    team_sync_dir = _team_sync_dir(root_dir, participant_hex, team_name)
+    endorser_private_key, endorser_public_key = get_current_team_device_key(
+        root_dir, participant_hex, team_name
     )
-    approver_device_key_id = key_id_from_public(approver_public_key)
+    endorser_device_key_id = key_id_from_public(endorser_public_key)
     with attached_note_to_self_connection(root_dir, participant_hex) as conn:
         row = conn.execute(
             "SELECT self_in_team FROM team WHERE name = ?",
@@ -4895,44 +5409,46 @@ def sign_steward_approval(root_dir, participant_hex, team_name, proposal_id_hex)
         ).fetchone()
     if row is None:
         raise ValueError(f"Team '{team_name}' not found in NoteToSelf")
-    steward_teammate_id = row[0]
+    endorser_teammate_id = row[0]
     failure_reason = None
     try:
         with engine.begin() as conn:
-            proposal_row = _load_admission_proposal_row(conn, proposal_id)
-            ok, reason = _proposal_is_still_valid(conn, proposal_row)
-            if not ok:
-                failure_reason = reason
-            elif proposal_row[17] is None:
-                raise ValueError("Proposal does not have a recorded transcript yet")
+            proposal_row = _load_proposal_row(conn, proposal_id)
+            block_reason = _admission_action_block_reason(conn, proposal_row)
+            acceptance_row = _load_acceptance_row(conn, proposal_id)
+            if block_reason is not None:
+                failure_reason = block_reason
+            elif acceptance_row is None:
+                raise ValueError("Proposal does not have a recorded acceptance yet")
             else:
-                snapshot = _load_governance_snapshot_json(proposal_row)
-                if not _proposal_steward_device_is_valid(snapshot, steward_teammate_id, approver_device_key_id):
-                    raise ValueError("Approver device was not linked to a steward at the proposal anchor")
-                signature = _sign_bytes(
-                    approver_private_key,
-                    _approval_payload(
-                        proposal_id=proposal_id,
-                        transcript_digest=proposal_row[17],
-                        steward_teammate_id=steward_teammate_id,
-                    ),
-                )
-                _insert_steward_approval(
+                # Re-verify the merged rows this endorsement vouches for before
+                # signing a digest over their contents.
+                _verify_proposal_row(conn, proposal_row)
+                _verify_acceptance_row(acceptance_row, proposal_row)
+                snapshot = _verified_proposal_snapshot(proposal_row)
+                integrators = _snapshot_core_integrator_devices(conn, snapshot)
+                if endorser_device_key_id.hex() not in integrators.get(
+                    endorser_teammate_id.hex(), set()
+                ):
+                    raise ValueError(
+                        "Endorsing device was not a current automatic Core integrator "
+                        "at the proposal anchor"
+                    )
+                _append_endorsement(
                     conn,
-                    proposal_id=proposal_id,
-                    steward_teammate_id=steward_teammate_id,
-                    approver_device_key_id=approver_device_key_id,
-                    signature=signature,
-                    transcript_digest=proposal_row[17],
+                    proposal_row=proposal_row,
+                    endorser_teammate_id=endorser_teammate_id,
+                    author_private_key=endorser_private_key,
+                    author_public_key=endorser_public_key,
+                    anchor_commit=_team_head_commit(team_sync_dir),
                 )
     finally:
         engine.dispose()
     if failure_reason is not None:
         raise ValueError(failure_reason)
-    repo_dir = _team_sync_dir(root_dir, participant_hex, team_name)
-    repo = _Repo(repo_dir / ".git", repo_dir)
+    repo = _Repo(team_sync_dir / ".git", team_sync_dir)
     repo.stage(["core.db"])
-    repo.commit("Recorded steward approval")
+    repo.commit("Recorded admission endorsement")
 
 
 def finalize_admission(root_dir, participant_hex, team_name, proposal_id_hex):
@@ -4941,10 +5457,9 @@ def finalize_admission(root_dir, participant_hex, team_name, proposal_id_hex):
     team_db_path = _team_db_path(root_dir, participant_hex, team_name)
     ensure_team_db_schema(team_db_path)
     engine = _sqlite_engine(team_db_path)
+    team_sync_dir = _team_sync_dir(root_dir, participant_hex, team_name)
     inviter_private_key, inviter_public_key = get_current_team_device_key(
-        root_dir,
-        participant_hex,
-        team_name,
+        root_dir, participant_hex, team_name
     )
     with attached_note_to_self_connection(root_dir, participant_hex) as conn:
         row = conn.execute(
@@ -4957,77 +5472,61 @@ def finalize_admission(root_dir, participant_hex, team_name, proposal_id_hex):
     failure_reason = None
     try:
         with engine.begin() as conn:
-            proposal_row = _load_admission_proposal_row(conn, proposal_id)
-            ok, reason = _proposal_is_still_valid(conn, proposal_row)
-            if not ok:
-                failure_reason = reason
-            elif proposal_row[3] != self_teammate_id:
+            proposal_row = _load_proposal_row(conn, proposal_id)
+            block_reason = _admission_action_block_reason(conn, proposal_row)
+            acceptance_row = _load_acceptance_row(conn, proposal_id)
+            if block_reason is not None:
+                failure_reason = block_reason
+            elif proposal_row[1] != self_teammate_id:
                 raise ValueError("Only the inviter may finalize this proposal")
-            elif proposal_row[17] is None or proposal_row[14] is None:
-                raise ValueError("Proposal transcript is incomplete")
-            elif not _proposal_has_quorum(conn, proposal_row):
-                raise ValueError("Proposal has not met quorum")
+            elif acceptance_row is None:
+                raise ValueError("Proposal does not have a recorded acceptance yet")
             else:
-                invitee_teammate_id = proposal_row[4]
-                invitee_device_public_key = proposal_row[14]
+                # Re-verify the merged rows and count only endorsements that
+                # verify end-to-end: the finalization record asserts this
+                # count, so it must not be signed over unchecked rows.
+                _verify_proposal_row(conn, proposal_row)
+                _verify_acceptance_row(acceptance_row, proposal_row)
+                endorsement_count = _count_valid_endorsements(conn, proposal_row, acceptance_row)
+                if endorsement_count < _proposal_quorum(conn):
+                    raise ValueError("Proposal has not met quorum")
+                invitee_teammate_id = proposal_row[9]
+                invitee_device_public_key = acceptance_row[10]
+                anchor_commit = _team_head_commit(team_sync_dir)
                 membership_cert = issue_membership_cert(
                     subject_key=_participant_key_from_public(invitee_device_public_key),
                     issuer_key=_participant_key_from_public(inviter_public_key),
                     issuer_private_key=inviter_private_key,
-                    team_id=proposal_row[2],
+                    team_id=proposal_row[8],
                     issuer_teammate_id=self_teammate_id,
                     admitted_teammate_id=invitee_teammate_id,
                 )
-                _upsert_teammate_row(conn, invitee_teammate_id, display_name=proposal_row[5])
+                _upsert_teammate_row(conn, invitee_teammate_id, display_name=proposal_row[13])
                 _store_team_certificate(conn, membership_cert, issuer_teammate_id=self_teammate_id)
                 _upsert_team_device_row(conn, invitee_teammate_id, invitee_device_public_key)
-                berth_rows = conn.execute(text("SELECT id FROM team_app_berth")).fetchall()
-                role = _role_to_core_berth_role(proposal_row[6])
-                for berth_row in berth_rows:
-                    existing = conn.execute(
-                        text(
-                            "SELECT 1 FROM berth_role WHERE teammate_id = :teammate_id AND berth_id = :berth_id"
-                        ),
-                        {"teammate_id": invitee_teammate_id, "berth_id": berth_row[0]},
-                    ).fetchone()
-                    if existing is None:
-                        conn.execute(
-                            text(
-                                "INSERT INTO berth_role (id, teammate_id, berth_id, role) "
-                                "VALUES (:id, :teammate_id, :berth_id, :role)"
-                            ),
-                            {
-                                "id": uuid7(),
-                                "teammate_id": invitee_teammate_id,
-                                "berth_id": berth_row[0],
-                                "role": role,
-                            },
-                        )
-                conn.execute(
-                    text(
-                        "UPDATE admission_proposal SET state = 'finalized', "
-                        "finalized_at = :finalized_at, finalization_signature = :finalization_signature "
-                        "WHERE proposal_id = :proposal_id"
-                    ),
-                    {
-                        "proposal_id": proposal_id,
-                        "finalized_at": _now_iso(),
-                        "finalization_signature": _sign_bytes(
-                            inviter_private_key,
-                            _finalization_payload(
-                                proposal_id=proposal_id,
-                                transcript_digest=proposal_row[17],
-                                invitee_teammate_id=invitee_teammate_id,
-                            ),
-                        ),
-                    },
+                _append_finalization(
+                    conn,
+                    proposal_row=proposal_row,
+                    finalizer_teammate_id=self_teammate_id,
+                    author_private_key=inviter_private_key,
+                    author_public_key=inviter_public_key,
+                    anchor_commit=anchor_commit,
+                    endorsement_count=endorsement_count,
+                )
+                _expand_mode_plan_at_finalization(
+                    conn,
+                    proposal_row=proposal_row,
+                    invitee_teammate_id=invitee_teammate_id,
+                    author_teammate_id=self_teammate_id,
+                    author_private_key=inviter_private_key,
+                    author_public_key=inviter_public_key,
+                    anchor_commit=anchor_commit,
                 )
     finally:
         engine.dispose()
     if failure_reason is not None:
         raise ValueError(failure_reason)
-    repo_dir = _team_sync_dir(root_dir, participant_hex, team_name)
-    repo = _Repo(repo_dir / ".git", repo_dir)
+    repo = _Repo(team_sync_dir / ".git", team_sync_dir)
     repo.stage(["core.db"])
     repo.commit("Finalized admission proposal")
 
@@ -5470,7 +5969,13 @@ def remove_cloud_storage(root_dir, participant_hex, storage_id_hex):
 
 
 def revoke_invitation(root_dir, participant_hex, team_name, invitation_id_hex):
-    """Invalidate an open admission proposal."""
+    """Record a revocation for an open admission proposal.
+
+    Revocation is a local disposition/projection, not a mutation of the
+    append-only proposal record: it inserts an `admission_revocation` row that
+    `_admission_status` reports as `invalidated`. (A signed revocation record is
+    future work -- see FOLLOW-UP.)
+    """
     root_dir = pathlib.Path(root_dir)
     team_db_path = (
         root_dir / "Participants" / participant_hex / team_name / "Sync" / "core.db"
@@ -5479,20 +5984,21 @@ def revoke_invitation(root_dir, participant_hex, team_name, invitation_id_hex):
     ensure_team_db_schema(team_db_path)
     engine = _sqlite_engine(team_db_path)
     with engine.begin() as conn:
-        row = conn.execute(
-            text("SELECT state FROM admission_proposal WHERE proposal_id = :id"),
-            {"id": invitation_id},
-        ).fetchone()
-        if row is None:
-            raise ValueError("Admission proposal not found")
-        if row[0] not in {"awaiting_invitee", "awaiting_quorum"}:
-            raise ValueError(f"Proposal is not revocable (state: {row[0]})")
+        proposal_row = _load_proposal_row(conn, invitation_id)
+        status = _admission_status(
+            conn,
+            record_id=invitation_id,
+            constitution_digest=proposal_row[5],
+            expires_at=proposal_row[11],
+        )
+        if status not in {"awaiting_invitee", "awaiting_quorum"}:
+            raise ValueError(f"Proposal is not revocable (status: {status})")
         conn.execute(
             text(
-                "UPDATE admission_proposal SET state = 'invalidated', invalid_reason = 'revoked' "
-                "WHERE proposal_id = :id"
+                "INSERT OR IGNORE INTO admission_revocation (subject_record_id, revoked_at) "
+                "VALUES (:id, :revoked_at)"
             ),
-            {"id": invitation_id},
+            {"id": invitation_id, "revoked_at": _now_iso()},
         )
     engine.dispose()
     team_sync_dir = root_dir / "Participants" / participant_hex / team_name / "Sync"
@@ -5592,24 +6098,34 @@ def list_invitations(root_dir, participant_hex, team_name):
     ensure_team_db_schema(team_db_path)
     engine = _sqlite_engine(team_db_path)
 
+    result = []
     with engine.begin() as conn:
         rows = conn.execute(
             text(
-                "SELECT proposal_id, state, invitee_label, role, created_at "
-                "FROM admission_proposal ORDER BY created_at DESC, proposal_id DESC"
+                "SELECT record_id, constitution_digest, expires_at, invitee_label_payload, "
+                "mode_plan, created_at "
+                "FROM admission_proposal ORDER BY created_at DESC, record_id DESC"
             )
         ).fetchall()
+        for record_id, constitution_digest, expires_at, label_payload, mode_plan, created_at in rows:
+            status = _admission_status(
+                conn,
+                record_id=record_id,
+                constitution_digest=constitution_digest,
+                expires_at=expires_at,
+            )
+            result.append(
+                {
+                    "id": record_id.hex(),
+                    "status": status,
+                    "invitee_label": label_payload,
+                    "role": preset_for_mode_plan(json.loads(mode_plan)) if mode_plan else None,
+                    "created_at": created_at,
+                }
+            )
 
-    return [
-        {
-            "id": row[0].hex(),
-            "status": row[1],
-            "invitee_label": row[2],
-            "role": row[3],
-            "created_at": row[4],
-        }
-        for row in rows
-    ]
+    engine.dispose()
+    return result
 
 
 def _admission_event_store_path(root_dir, participant_hex, team_name):

--- a/packages/small-sea-manager/small_sea_manager/sql/core_other_team.sql
+++ b/packages/small-sea-manager/small_sea_manager/sql/core_other_team.sql
@@ -46,42 +46,131 @@ CREATE TABLE IF NOT EXISTS team_setting (
     value TEXT NOT NULL
 );
 
+-- The quorum-gated admission flow as append-only Team Constitution records
+-- (see Documentation/team-constitution.md and issue #164). All four record
+-- tables below share the `integration_mode_change` envelope prefix
+-- (record_id/record_type/author_*/created_at/anchor_commit/constitution_*
+-- /schema_version/signature) and are NEVER mutated: admission status is a
+-- computed view over which of these rows exist (see `_admission_status`),
+-- not a stored column.
+--
+-- `admission_proposal`: the inviter's signed offer. `invitee_teammate_id` is
+-- pre-allocated (the invitee is not a teammate yet, so there is no FK on it).
+-- `invitee_label_commitment` is the signed PII commitment (nullable and left
+-- unpopulated in this slice, per #168 -- the column fixes the schema shape).
+-- `mode_plan` is the inviter's starting-mode intent as the canonical JSON
+-- expansion rule {"core_mode":...,"other_mode":...} (preset vocabulary is
+-- never stored -- see architecture.md). It is SIGNED into the canonical
+-- bytes: finalization expands it into the invitee's granted authority, so a
+-- droppable/unsigned plan would let anyone escalate a proposal undetected.
+-- `invitee_label_payload` is the one separable, unsigned column excluded
+-- from the canonical signed bytes: the plain label is droppable PII.
 CREATE TABLE IF NOT EXISTS admission_proposal (
-    proposal_id BLOB PRIMARY KEY,
+    record_id BLOB PRIMARY KEY,
+    record_type TEXT NOT NULL DEFAULT 'admission_proposal',
+    author_teammate_id BLOB NOT NULL,
+    author_device_key_id BLOB NOT NULL,
+    created_at TEXT NOT NULL,
+    anchor_commit TEXT,
+    constitution_digest BLOB NOT NULL,
+    constitution_snapshot_json TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1,
     nonce BLOB NOT NULL,
     team_id BLOB NOT NULL,
-    inviter_teammate_id BLOB NOT NULL,
     invitee_teammate_id BLOB NOT NULL,
-    invitee_label TEXT,
-    role TEXT NOT NULL DEFAULT 'steward',
-    anchor_commit TEXT NOT NULL,
-    governance_digest BLOB NOT NULL,
-    governance_snapshot_json TEXT NOT NULL,
-    state TEXT NOT NULL,
-    created_at TEXT NOT NULL,
+    invitee_label_commitment BLOB,
     expires_at TEXT NOT NULL,
-    acceptance_recorded_at TEXT,
-    invitee_device_public_key BLOB,
-    invitee_bootstrap_key BLOB,
-    acceptance_signature BLOB,
-    transcript_digest BLOB,
-    transcript_json TEXT,
-    finalized_at TEXT,
-    finalization_signature BLOB,
-    invalid_reason TEXT
+    mode_plan TEXT NOT NULL,
+    signature BLOB NOT NULL,
+    invitee_label_payload TEXT,
+    FOREIGN KEY (author_teammate_id) REFERENCES teammate(id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS steward_approval (
-    approval_id BLOB PRIMARY KEY,
-    proposal_id BLOB NOT NULL,
-    steward_teammate_id BLOB NOT NULL,
-    approver_device_key_id BLOB NOT NULL,
-    transcript_digest BLOB NOT NULL,
-    signature BLOB NOT NULL,
+-- `admission_acceptance`: constructed and signed invitee-side, transported and
+-- inserted verbatim inviter-side. The envelope's anchor_commit/constitution_*
+-- are NULL: the invitee signs before having any standing to attest to a
+-- governance view. This is the one record whose signature is verified against
+-- an *embedded* key (`invitee_device_public_key`) rather than the cert graph
+-- because the signer has no membership yet. `author_device_key_id` must equal
+-- the key id derived from that embedded key.
+CREATE TABLE IF NOT EXISTS admission_acceptance (
+    record_id BLOB PRIMARY KEY,
+    record_type TEXT NOT NULL DEFAULT 'admission_acceptance',
+    author_teammate_id BLOB NOT NULL,
+    author_device_key_id BLOB NOT NULL,
     created_at TEXT NOT NULL,
-    UNIQUE (proposal_id, approver_device_key_id),
-    FOREIGN KEY (proposal_id) REFERENCES admission_proposal(proposal_id) ON DELETE CASCADE
+    anchor_commit TEXT,
+    constitution_digest BLOB,
+    constitution_snapshot_json TEXT,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    subject_record_id BLOB NOT NULL,
+    nonce BLOB NOT NULL,
+    invitee_device_public_key BLOB NOT NULL,
+    invitee_bootstrap_key BLOB NOT NULL,
+    signature BLOB NOT NULL,
+    FOREIGN KEY (subject_record_id) REFERENCES admission_proposal(record_id) ON DELETE CASCADE
 );
+
+-- `endorsement`: an automatic Core integrator (UI "steward") vouching for a
+-- reviewed acceptance. `subject_digest` is a content commitment (sha256) over
+-- the endorsed `admission_acceptance`'s canonical bytes. The UNIQUE constraint
+-- dedupes per endorsing teammate (not per device), so quorum is a plain
+-- COUNT(*) and one steward's two linked devices count once.
+CREATE TABLE IF NOT EXISTS endorsement (
+    record_id BLOB PRIMARY KEY,
+    record_type TEXT NOT NULL DEFAULT 'endorsement',
+    author_teammate_id BLOB NOT NULL,
+    author_device_key_id BLOB NOT NULL,
+    created_at TEXT NOT NULL,
+    anchor_commit TEXT,
+    constitution_digest BLOB NOT NULL,
+    constitution_snapshot_json TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    subject_record_id BLOB NOT NULL,
+    subject_digest BLOB NOT NULL,
+    signature BLOB NOT NULL,
+    UNIQUE (subject_record_id, author_teammate_id),
+    FOREIGN KEY (author_teammate_id) REFERENCES teammate(id) ON DELETE CASCADE,
+    FOREIGN KEY (subject_record_id) REFERENCES admission_proposal(record_id) ON DELETE CASCADE
+);
+
+-- `finalization`: the terminal record. Only its presence makes a proposal
+-- effective (drives every projection write and `_admission_status`).
+-- `endorsement_count` records the observed count that met quorum.
+CREATE TABLE IF NOT EXISTS finalization (
+    record_id BLOB PRIMARY KEY,
+    record_type TEXT NOT NULL DEFAULT 'finalization',
+    author_teammate_id BLOB NOT NULL,
+    author_device_key_id BLOB NOT NULL,
+    created_at TEXT NOT NULL,
+    anchor_commit TEXT,
+    constitution_digest BLOB NOT NULL,
+    constitution_snapshot_json TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    subject_record_id BLOB NOT NULL,
+    subject_digest BLOB NOT NULL,
+    endorsement_count INTEGER NOT NULL,
+    signature BLOB NOT NULL,
+    FOREIGN KEY (author_teammate_id) REFERENCES teammate(id) ON DELETE CASCADE,
+    FOREIGN KEY (subject_record_id) REFERENCES admission_proposal(record_id) ON DELETE CASCADE
+);
+
+-- Revocation is a local disposition/projection, not one of the signed record
+-- types above: an inviter deciding not to proceed. Modeling it as a signed
+-- Constitution record is future work (see FOLLOW-UP). Keeping it a mutable
+-- projection preserves append-only discipline on the four record tables.
+CREATE TABLE IF NOT EXISTS admission_revocation (
+    subject_record_id BLOB PRIMARY KEY,
+    revoked_at TEXT NOT NULL,
+    FOREIGN KEY (subject_record_id) REFERENCES admission_proposal(record_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_admission_acceptance_scan
+    ON admission_acceptance(subject_record_id, record_id);
+CREATE INDEX IF NOT EXISTS idx_endorsement_scan
+    ON endorsement(subject_record_id, record_id);
+CREATE INDEX IF NOT EXISTS idx_finalization_scan
+    ON finalization(subject_record_id, record_id);
 
 CREATE TABLE IF NOT EXISTS team_device (
     device_key_id BLOB PRIMARY KEY,
@@ -135,8 +224,8 @@ CREATE INDEX IF NOT EXISTS idx_teammate_berth_storage_announcement_scan
 -- `constitution_digest`/`constitution_snapshot_json` are a Phase 1 stand-in
 -- for the doc's target `anchor_frontier` mechanism (see that phase's
 -- Archive/design-record for why): a live-query digest over current
--- teammate/device/berth-role state, generalizing `admission_proposal`'s
--- existing `governance_digest` beyond just Core stewards.
+-- teammate/device/berth-role state. The admission record tables above share
+-- this same envelope and interim anchor.
 CREATE TABLE IF NOT EXISTS integration_mode_change (
     record_id BLOB PRIMARY KEY,
     record_type TEXT NOT NULL DEFAULT 'integration_mode_change',

--- a/packages/small-sea-manager/small_sea_manager/web.py
+++ b/packages/small-sea-manager/small_sea_manager/web.py
@@ -483,8 +483,8 @@ def create_app(root_dir: str, participant_hex: str, hub_port: int = 11437) -> Fa
     async def approve_invitation(request: Request, team_name: str, inv_id: str):
         mgr = _mgr(request)
         try:
-            mgr.sign_steward_approval(team_name, inv_id)
-            notice = "Steward approval recorded."
+            mgr.endorse_admission(team_name, inv_id)
+            notice = "Endorsement recorded."
             error = None
         except Exception as e:
             notice = None

--- a/packages/small-sea-manager/tests/test_admission_proposals.py
+++ b/packages/small-sea-manager/tests/test_admission_proposals.py
@@ -126,7 +126,7 @@ def test_quorum_two_requires_second_steward_and_inviter_finalization(playground_
     assert proposals[0]["status"] == "awaiting_quorum"
 
     shutil.copy2(alice_sync / "core.db", carol_sync / "core.db")
-    provisioning.sign_steward_approval(root, carol_hex, "ProjectX", proposals[0]["id"])
+    provisioning.endorse_admission(root, carol_hex, "ProjectX", proposals[0]["id"])
     shutil.copy2(carol_sync / "core.db", alice_sync / "core.db")
 
     provisioning.finalize_admission(root, alice_hex, "ProjectX", proposals[0]["id"])
@@ -183,12 +183,11 @@ def test_governance_drift_invalidates_proposal(playground_dir):
 
 
 def test_contributor_role_finalizes_as_proposal_only_on_core(playground_dir):
-    # A contributor is proposal-only on Core (spec.md: proposal-only on Core,
-    # automatic on other berths). This asserts the Core mapping only, which the
-    # projection currently stores as `read-only`. Per-berth expansion of the
-    # preset -- automatic on non-Core berths -- is not implemented yet; admission
-    # fans the single Core mode out to every berth. That expansion is tracked in
-    # issue #164 (preset becomes per-berth integration_mode_change records).
+    # A contributor is proposal-only on Core (architecture.md: proposal-only on
+    # Core, automatic on other berths). Finalization now expands the preset into
+    # per-berth integration_mode_change records (issue #164); the Core berth
+    # gets `core_mode` (proposal-only -> `read-only` projection). A fixture with
+    # a non-Core berth is exercised in test_admission_records.py.
     root = pathlib.Path(playground_dir)
     alice_cloud = root / "alice-cloud"
     alice_cloud.mkdir()
@@ -206,7 +205,7 @@ def test_contributor_role_finalizes_as_proposal_only_on_core(playground_dir):
         "ProjectX",
         {"protocol": "localfolder", "url": str(alice_cloud)},
         invitee_label="Bob",
-        role="contributor",
+        mode_plan=provisioning.mode_plan_for_preset("contributor"),
     )
     acceptance = provisioning.accept_invitation(
         root,

--- a/packages/small-sea-manager/tests/test_admission_records.py
+++ b/packages/small-sea-manager/tests/test_admission_records.py
@@ -1,0 +1,1064 @@
+"""Micro tests for admission-as-Constitution-records (issue #164).
+
+These exercise the four append-only record types (proposal / acceptance /
+endorsement / finalization) directly: signatures verify through
+`wrasse_trust.constitution` against independently recomputed canonical bytes,
+the self-certifying acceptance rejects a substituted key, the separable
+label payload really is separable, the steward/contributor preset expands
+per-berth, one steward's two devices count once, and refusals never mutate a
+row. The tamper tests at the bottom cover the 2026-07-04 committee findings:
+the signed mode_plan cannot be escalated or dropped, and forged
+endorsement/acceptance/snapshot rows are refused at decision points.
+
+Runs entirely over LocalFolderRemote -- no MinIO or Hub.
+"""
+
+import base64
+import json
+import pathlib
+import shutil
+import sqlite3
+
+import cod_sync.protocol as CS
+import pytest
+
+import small_sea_manager.provisioning as provisioning
+from wrasse_trust.constitution import (
+    canonical_constitution_bytes,
+    derive_record_id,
+    sign_constitution_record,
+    verify_constitution_record,
+)
+from wrasse_trust.keys import ProtectionLevel, generate_key_pair, key_id_from_public
+
+
+def _push(repo_dir: pathlib.Path, cloud_dir: pathlib.Path):
+    cod = CS.CodSync("origin", repo_dir=repo_dir)
+    cod.remote = CS.LocalFolderRemote(str(cloud_dir))
+    cod.push_to_remote(["main"])
+
+
+def _setup_team(root: pathlib.Path, *, quorum: int | None = None):
+    cloud = root / "alice-cloud"
+    cloud.mkdir()
+    alice_hex = provisioning.create_new_participant(root, "Alice")
+    bob_hex = provisioning.create_new_participant(root, "Bob")
+    provisioning.add_cloud_storage(root, alice_hex, protocol="localfolder", url=str(cloud))
+    provisioning.create_team(root, alice_hex, "ProjectX")
+    if quorum is not None:
+        provisioning.set_team_admission_policy(root, alice_hex, "ProjectX", quorum=quorum)
+    alice_sync = root / "Participants" / alice_hex / "ProjectX" / "Sync"
+    _push(alice_sync, cloud)
+    return alice_hex, bob_hex, cloud, alice_sync
+
+
+def _admit(root, alice_hex, invitee_hex, cloud, *, mode_plan=None, label="Bob"):
+    """Run a quorum-1 admission end to end; returns the acceptance token dict."""
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label=label,
+        mode_plan=mode_plan,
+    )
+    _push(root / "Participants" / alice_hex / "ProjectX" / "Sync", cloud)
+    acceptance = provisioning.accept_invitation(
+        root, invitee_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+    return json.loads(base64.b64decode(acceptance).decode())
+
+
+def _device_public_key(conn, device_key_id: bytes) -> bytes:
+    return conn.execute(
+        "SELECT public_key FROM team_device WHERE device_key_id = ?", (device_key_id,)
+    ).fetchone()[0]
+
+
+def _hexn(value) -> str | None:
+    return value.hex() if value is not None else None
+
+
+# --------------------------------------------------------------------------- #
+# 1. Every finalized-admission record verifies against recomputed canonical bytes
+# --------------------------------------------------------------------------- #
+
+
+def test_finalized_admission_writes_four_verifiable_records(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    _admit(root, alice_hex, bob_hex, cloud)
+
+    db = alice_sync / "core.db"
+    with sqlite3.connect(str(db)) as conn:
+        proposal = conn.execute(
+            "SELECT record_id, record_type, author_teammate_id, author_device_key_id, "
+            "created_at, anchor_commit, constitution_digest, nonce, team_id, "
+            "invitee_teammate_id, invitee_label_commitment, expires_at, signature, mode_plan "
+            "FROM admission_proposal"
+        ).fetchone()
+        acceptance = conn.execute(
+            "SELECT record_id, record_type, author_teammate_id, author_device_key_id, "
+            "created_at, subject_record_id, nonce, invitee_device_public_key, "
+            "invitee_bootstrap_key, signature FROM admission_acceptance"
+        ).fetchone()
+        endorsement = conn.execute(
+            "SELECT record_type, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, subject_record_id, subject_digest, signature "
+            "FROM endorsement"
+        ).fetchone()
+        finalization = conn.execute(
+            "SELECT record_type, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, subject_record_id, subject_digest, "
+            "endorsement_count, signature FROM finalization"
+        ).fetchone()
+
+        # -- proposal: signed by the inviter's device, no embedded invitee key --
+        p_signed = {
+            "record_type": proposal[1],
+            "author_teammate_id": proposal[2].hex(),
+            "author_device_key_id": proposal[3].hex(),
+            "created_at": proposal[4],
+            "anchor_commit": proposal[5],
+            "constitution_digest": proposal[6].hex(),
+            "schema_version": 1,
+            "nonce": proposal[7].hex(),
+            "team_id": proposal[8].hex(),
+            "invitee_teammate_id": proposal[9].hex(),
+            "invitee_label_commitment": _hexn(proposal[10]),
+            "expires_at": proposal[11],
+            "mode_plan": json.loads(proposal[13]),
+        }
+        assert verify_constitution_record(
+            _device_public_key(conn, proposal[3]),
+            canonical_constitution_bytes(p_signed),
+            proposal[12],
+        )
+
+        # -- acceptance: self-certified by its own embedded device key --
+        a_signed = {
+            "record_type": acceptance[1],
+            "author_teammate_id": acceptance[2].hex(),
+            "author_device_key_id": acceptance[3].hex(),
+            "created_at": acceptance[4],
+            "anchor_commit": None,
+            "constitution_digest": None,
+            "schema_version": 1,
+            "subject_record_id": acceptance[5].hex(),
+            "nonce": acceptance[6].hex(),
+            "invitee_device_public_key": acceptance[7].hex(),
+            "invitee_bootstrap_key": acceptance[8].hex(),
+        }
+        assert verify_constitution_record(
+            acceptance[7], canonical_constitution_bytes(a_signed), acceptance[9]
+        )
+
+        # -- endorsement + finalization: signed by the inviter's device --
+        for rec in (endorsement, finalization):
+            signed = {
+                "record_type": rec[0],
+                "author_teammate_id": rec[1].hex(),
+                "author_device_key_id": rec[2].hex(),
+                "created_at": rec[3],
+                "anchor_commit": rec[4],
+                "constitution_digest": rec[5].hex(),
+                "schema_version": 1,
+                "subject_record_id": rec[6].hex(),
+                "subject_digest": rec[7].hex(),
+            }
+            if rec is finalization:
+                signed["endorsement_count"] = rec[8]
+            signature = rec[-1]
+            assert verify_constitution_record(
+                _device_public_key(conn, rec[2]),
+                canonical_constitution_bytes(signed),
+                signature,
+            )
+
+        # subject_digest is the untruncated commitment over the acceptance's bytes
+        assert endorsement[7] == finalization[7]
+        assert endorsement[7][:16] == acceptance[0]  # record_id = sha256(canonical)[:16]
+
+
+# --------------------------------------------------------------------------- #
+# 2. Separable columns are excluded from the signed bytes
+# --------------------------------------------------------------------------- #
+
+
+def test_separable_label_payload_does_not_affect_proposal_signature(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+        mode_plan=provisioning.mode_plan_for_preset("contributor"),
+    )
+
+    db = alice_sync / "core.db"
+    with sqlite3.connect(str(db)) as conn:
+        # Drop the separable label payload entirely, as a syncing peer may.
+        # mode_plan is deliberately NOT separable: it is signed (see the
+        # tamper tests below).
+        conn.execute("UPDATE admission_proposal SET invitee_label_payload = NULL")
+        conn.commit()
+        row = conn.execute(
+            "SELECT author_device_key_id, created_at, anchor_commit, constitution_digest, "
+            "nonce, team_id, invitee_teammate_id, invitee_label_commitment, expires_at, "
+            "author_teammate_id, signature, mode_plan FROM admission_proposal"
+        ).fetchone()
+        signed = {
+            "record_type": "admission_proposal",
+            "author_teammate_id": row[9].hex(),
+            "author_device_key_id": row[0].hex(),
+            "created_at": row[1],
+            "anchor_commit": row[2],
+            "constitution_digest": row[3].hex(),
+            "schema_version": 1,
+            "nonce": row[4].hex(),
+            "team_id": row[5].hex(),
+            "invitee_teammate_id": row[6].hex(),
+            "invitee_label_commitment": _hexn(row[7]),
+            "expires_at": row[8],
+            "mode_plan": json.loads(row[11]),
+        }
+        assert verify_constitution_record(
+            _device_public_key(conn, row[0]), canonical_constitution_bytes(signed), row[10]
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 3. Self-certification boundary
+# --------------------------------------------------------------------------- #
+
+
+def _make_proposal_and_accept(root, alice_hex, bob_hex, cloud):
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+    )
+    _push(root / "Participants" / alice_hex / "ProjectX" / "Sync", cloud)
+    acceptance_b64 = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    return json.loads(base64.b64decode(acceptance_b64).decode())
+
+
+def _retokenize(acceptance_dict) -> str:
+    return base64.b64encode(
+        json.dumps(acceptance_dict, sort_keys=True, separators=(",", ":")).encode()
+    ).decode()
+
+
+def test_acceptance_signed_by_other_key_is_rejected(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    acceptance = _make_proposal_and_accept(root, alice_hex, bob_hex, cloud)
+
+    # Swap in a different embedded device key. The recorded signature no longer
+    # matches, and author_device_key_id no longer matches the embedded key.
+    other_key, _ = generate_key_pair(ProtectionLevel.DAILY)
+    acceptance["invitee_device_public_key"] = other_key.public_key.hex()
+
+    with pytest.raises(ValueError, match="signature is invalid|does not match its embedded"):
+        provisioning.complete_invitation_acceptance(
+            root, alice_hex, "ProjectX", _retokenize(acceptance)
+        )
+
+
+def test_acceptance_with_wrong_nonce_is_rejected(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    acceptance = _make_proposal_and_accept(root, alice_hex, bob_hex, cloud)
+
+    # Flip the nonce: canonical bytes change, so the self-certifying record_id
+    # check fails before anything touches the proposal.
+    acceptance["nonce"] = ("f" * len(acceptance["nonce"]))
+
+    with pytest.raises(ValueError, match="record_id does not match|nonce does not match"):
+        provisioning.complete_invitation_acceptance(
+            root, alice_hex, "ProjectX", _retokenize(acceptance)
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 4. Preset expansion per architecture.md (contributor: proposal-only on Core,
+#    automatic elsewhere) -- fails against a uniform-role implementation.
+# --------------------------------------------------------------------------- #
+
+
+def test_contributor_preset_expands_per_berth(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    db = alice_sync / "core.db"
+
+    # Add a second, non-Core berth to the team before admission.
+    other_app_id = provisioning.uuid7()
+    other_berth_id = provisioning.uuid7()
+    with sqlite3.connect(str(db)) as conn:
+        conn.execute("INSERT INTO app (id, name) VALUES (?, ?)", (other_app_id, "SscFiles"))
+        conn.execute(
+            "INSERT INTO team_app_berth (id, app_id) VALUES (?, ?)",
+            (other_berth_id, other_app_id),
+        )
+        conn.commit()
+    repo = provisioning._Repo(alice_sync / ".git", alice_sync)
+    repo.stage(["core.db"])
+    repo.commit("Add non-Core berth")
+    _push(alice_sync, cloud)
+
+    acceptance = _admit(
+        root, alice_hex, bob_hex, cloud,
+        mode_plan=provisioning.mode_plan_for_preset("contributor"),
+    )
+    bob_teammate_id = bytes.fromhex(acceptance["author_teammate_id"])
+
+    with sqlite3.connect(str(db)) as conn:
+        core_berth_id = conn.execute(
+            "SELECT tab.id FROM team_app_berth tab JOIN app a ON a.id = tab.app_id "
+            "WHERE a.name = 'SmallSeaCollectiveCore'"
+        ).fetchone()[0]
+
+        modes = dict(
+            conn.execute(
+                "SELECT berth_id, mode FROM integration_mode_change WHERE teammate_id = ?",
+                (bob_teammate_id,),
+            ).fetchall()
+        )
+        assert modes[core_berth_id] == "proposal-only"
+        assert modes[other_berth_id] == "automatic"
+
+        roles = dict(
+            conn.execute(
+                "SELECT berth_id, role FROM berth_role WHERE teammate_id = ?",
+                (bob_teammate_id,),
+            ).fetchall()
+        )
+        assert roles[core_berth_id] == "read-only"
+        assert roles[other_berth_id] == "read-write"
+
+        # Each expansion record independently verifies.
+        for berth_id, signature, author_device_key_id, created_at, anchor_commit, digest, mode in conn.execute(
+            "SELECT berth_id, signature, author_device_key_id, created_at, anchor_commit, "
+            "constitution_digest, mode FROM integration_mode_change WHERE teammate_id = ?",
+            (bob_teammate_id,),
+        ).fetchall():
+            signed = {
+                "record_type": "integration_mode_change",
+                "author_teammate_id": provisioning._team_row(root, alice_hex, "ProjectX")[1].hex(),
+                "author_device_key_id": author_device_key_id.hex(),
+                "created_at": created_at,
+                "anchor_commit": anchor_commit,
+                "constitution_digest": digest.hex(),
+                "schema_version": 1,
+                "teammate_id": bob_teammate_id.hex(),
+                "berth_id": berth_id.hex(),
+                "mode": mode,
+            }
+            assert verify_constitution_record(
+                _device_public_key(conn, author_device_key_id),
+                canonical_constitution_bytes(signed),
+                signature,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# 5. The double-count fix: one steward's two devices endorse once
+# --------------------------------------------------------------------------- #
+
+
+def test_one_steward_two_devices_endorse_once(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root, quorum=2)
+    # Quorum 2: acceptance records Alice's single auto-endorsement, then stays
+    # awaiting_quorum (no projections).
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+    )
+    _push(alice_sync, cloud)
+    acceptance = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+
+    db = alice_sync / "core.db"
+    engine = provisioning._sqlite_engine(db)
+    alice_teammate_id = provisioning._team_row(root, alice_hex, "ProjectX")[1]
+    with engine.begin() as conn:
+        proposal_id = conn.execute(
+            provisioning.text("SELECT record_id FROM admission_proposal")
+        ).fetchone()[0]
+        proposal_row = provisioning._load_proposal_row(conn, proposal_id)
+        assert provisioning._endorsement_count(conn, proposal_id) == 1
+
+        # Alice endorses again from a *second* device (fresh keypair, same
+        # teammate). The UNIQUE(subject_record_id, author_teammate_id) constraint
+        # keeps the count at 1 -- the old per-device dedupe would have made it 2.
+        second_device, second_private = generate_key_pair(ProtectionLevel.DAILY)
+        provisioning._append_endorsement(
+            conn,
+            proposal_row=proposal_row,
+            endorser_teammate_id=alice_teammate_id,
+            author_private_key=second_private,
+            author_public_key=second_device.public_key,
+            anchor_commit=None,
+        )
+        assert provisioning._endorsement_count(conn, proposal_id) == 1
+    engine.dispose()
+
+
+# --------------------------------------------------------------------------- #
+# 6. Refusals don't mutate: an expired proposal rejects endorsement, unchanged
+# --------------------------------------------------------------------------- #
+
+
+def test_expired_proposal_refuses_endorsement_without_mutation(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root, quorum=2)
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+    )
+    _push(alice_sync, cloud)
+    acceptance = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+
+    db = alice_sync / "core.db"
+    proposal_id_hex = provisioning.list_invitations(root, alice_hex, "ProjectX")[0]["id"]
+
+    # Force the (unsigned-view) expiry into the past; the signed digest column is
+    # untouched, so this only flips the computed status to `expired`.
+    with sqlite3.connect(str(db)) as conn:
+        conn.execute(
+            "UPDATE admission_proposal SET expires_at = '2000-01-01T00:00:00+00:00'"
+        )
+        conn.commit()
+        before = conn.execute("SELECT COUNT(*) FROM endorsement").fetchone()[0]
+
+    with pytest.raises(ValueError, match="expired"):
+        provisioning.endorse_admission(root, alice_hex, "ProjectX", proposal_id_hex)
+
+    with sqlite3.connect(str(db)) as conn:
+        after = conn.execute("SELECT COUNT(*) FROM endorsement").fetchone()[0]
+        assert after == before  # refusal added no endorsement
+        assert provisioning.list_invitations(root, alice_hex, "ProjectX")[0]["status"] == "expired"
+
+
+# --------------------------------------------------------------------------- #
+# 7. Committee finding 1: mode_plan is signed -- it cannot be escalated or
+#    dropped between proposal creation and finalization.
+# --------------------------------------------------------------------------- #
+
+
+def test_tampered_mode_plan_blocks_completion(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+        mode_plan=provisioning.mode_plan_for_preset("contributor"),
+    )
+    _push(alice_sync, cloud)
+    acceptance = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+
+    # Escalate the stored plan to the steward expansion, as a malicious merge
+    # could. The plan is inside the signed canonical bytes, so the record no
+    # longer matches its record_id/signature.
+    db = alice_sync / "core.db"
+    steward_plan = json.dumps(
+        provisioning.mode_plan_for_preset("steward"), sort_keys=True, separators=(",", ":")
+    )
+    with sqlite3.connect(str(db)) as conn:
+        conn.execute("UPDATE admission_proposal SET mode_plan = ?", (steward_plan,))
+        conn.commit()
+
+    with pytest.raises(ValueError, match="record_id does not match|signature is invalid"):
+        provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+
+    with sqlite3.connect(str(db)) as conn:
+        # Refused before any admission side effect: no teammate, no finalization.
+        assert conn.execute("SELECT COUNT(*) FROM teammate").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM finalization").fetchone()[0] == 0
+        # And the drop attack is gone at the schema level: mode_plan is NOT NULL.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("UPDATE admission_proposal SET mode_plan = NULL")
+
+
+# --------------------------------------------------------------------------- #
+# 8. Committee finding 2: quorum counts only endorsements that verify
+#    end-to-end. A well-formed row forged in a real steward's name (signed by
+#    an attacker key) meets the old COUNT(*) quorum but not the validated one.
+# --------------------------------------------------------------------------- #
+
+
+def test_forged_endorsements_do_not_count_toward_quorum(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    carol_hex = provisioning.create_new_participant(root, "Carol")
+    _admit(root, alice_hex, carol_hex, cloud, label="Carol")  # second steward
+    provisioning.set_team_admission_policy(root, alice_hex, "ProjectX", quorum=2)
+    _push(alice_sync, cloud)
+
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+    )
+    _push(alice_sync, cloud)
+    acceptance = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+    proposals = provisioning.list_invitations(root, alice_hex, "ProjectX")
+    proposal_hex = next(p["id"] for p in proposals if p["status"] == "awaiting_quorum")
+    proposal_id = bytes.fromhex(proposal_hex)
+
+    # Give Carol her own up-to-date replica before Alice's gets poisoned.
+    carol_sync = root / "Participants" / carol_hex / "ProjectX" / "Sync"
+    shutil.copy2(alice_sync / "core.db", carol_sync / "core.db")
+
+    # Forge an endorsement in Carol's name: correct author/device ids, correct
+    # subject_digest and constitution_digest, correctly derived record_id --
+    # but signed by an attacker key instead of Carol's device key.
+    db = alice_sync / "core.db"
+    with sqlite3.connect(str(db)) as conn:
+        carol_teammate_id, carol_device_key_id = conn.execute(
+            "SELECT m.id, d.device_key_id FROM teammate m "
+            "JOIN team_device d ON d.teammate_id = m.id WHERE m.display_name = 'Carol'"
+        ).fetchone()
+        proposal_digest, snapshot_json = conn.execute(
+            "SELECT constitution_digest, constitution_snapshot_json "
+            "FROM admission_proposal WHERE record_id = ?",
+            (proposal_id,),
+        ).fetchone()
+        subject_digest = conn.execute(
+            "SELECT subject_digest FROM endorsement WHERE subject_record_id = ?",
+            (proposal_id,),
+        ).fetchone()[0]
+        _attacker_key, attacker_private = generate_key_pair(ProtectionLevel.DAILY)
+        now = provisioning._now_iso()
+        forged_signed = {
+            **provisioning._record_envelope_fields(
+                record_type="endorsement",
+                author_teammate_id=carol_teammate_id,
+                author_device_key_id=carol_device_key_id,
+                created_at=now,
+                anchor_commit=None,
+                constitution_digest=proposal_digest,
+            ),
+            "subject_record_id": proposal_id.hex(),
+            "subject_digest": subject_digest.hex(),
+        }
+        forged_canonical = canonical_constitution_bytes(forged_signed)
+        conn.execute(
+            "INSERT INTO endorsement ("
+            "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+            "subject_record_id, subject_digest, signature) "
+            "VALUES (?, 'endorsement', ?, ?, ?, NULL, ?, ?, 1, ?, ?, ?)",
+            (
+                derive_record_id(forged_canonical),
+                carol_teammate_id,
+                carol_device_key_id,
+                now,
+                proposal_digest,
+                snapshot_json,
+                proposal_id,
+                subject_digest,
+                sign_constitution_record(attacker_private, forged_canonical),
+            ),
+        )
+        conn.commit()
+        # The raw row count now meets quorum: the pre-fix COUNT(*) check would
+        # have finalized on the forged row.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM endorsement WHERE subject_record_id = ?", (proposal_id,)
+        ).fetchone()[0] == 2
+
+    with pytest.raises(ValueError, match="quorum"):
+        provisioning.finalize_admission(root, alice_hex, "ProjectX", proposal_hex)
+
+    # A genuine endorsement from Carol's real device key does meet quorum.
+    provisioning.endorse_admission(root, carol_hex, "ProjectX", proposal_hex)
+    shutil.copy2(carol_sync / "core.db", alice_sync / "core.db")
+    provisioning.finalize_admission(root, alice_hex, "ProjectX", proposal_hex)
+    statuses = {
+        p["id"]: p["status"] for p in provisioning.list_invitations(root, alice_hex, "ProjectX")
+    }
+    assert statuses[proposal_hex] == "finalized"
+
+
+# --------------------------------------------------------------------------- #
+# 9. The unsigned snapshot JSON is bound to the signed digest before any
+#    eligibility decision reads it.
+# --------------------------------------------------------------------------- #
+
+
+def test_tampered_snapshot_json_is_rejected_against_signed_digest(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root, quorum=2)
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+    )
+    _push(alice_sync, cloud)
+    acceptance = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+    proposal_hex = provisioning.list_invitations(root, alice_hex, "ProjectX")[0]["id"]
+
+    # Graft an attacker device onto the snapshot's device list. The JSON column
+    # is not itself signed; the digest binding must catch the mismatch.
+    db = alice_sync / "core.db"
+    with sqlite3.connect(str(db)) as conn:
+        snapshot = json.loads(
+            conn.execute("SELECT constitution_snapshot_json FROM admission_proposal").fetchone()[0]
+        )
+        attacker_key, _ = generate_key_pair(ProtectionLevel.DAILY)
+        teammate_hex = next(iter(snapshot["teammate_devices"]))
+        snapshot["teammate_devices"][teammate_hex].append(
+            key_id_from_public(attacker_key.public_key).hex()
+        )
+        conn.execute(
+            "UPDATE admission_proposal SET constitution_snapshot_json = ?",
+            (json.dumps(snapshot, sort_keys=True),),
+        )
+        conn.commit()
+
+    with pytest.raises(ValueError, match="snapshot does not match its signed digest"):
+        provisioning.endorse_admission(root, alice_hex, "ProjectX", proposal_hex)
+
+
+# --------------------------------------------------------------------------- #
+# 10. A merged acceptance row is re-verified at finalization, not trusted as
+#     already-checked local state.
+# --------------------------------------------------------------------------- #
+
+
+def test_tampered_acceptance_row_is_rejected_at_finalization(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root, quorum=2)
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+    )
+    _push(alice_sync, cloud)
+    acceptance = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+    proposal_hex = provisioning.list_invitations(root, alice_hex, "ProjectX")[0]["id"]
+
+    # Swap the embedded self-certification key for an attacker's, as a merged
+    # row could carry.
+    db = alice_sync / "core.db"
+    with sqlite3.connect(str(db)) as conn:
+        attacker_key, _ = generate_key_pair(ProtectionLevel.DAILY)
+        conn.execute(
+            "UPDATE admission_acceptance SET invitee_device_public_key = ?",
+            (attacker_key.public_key,),
+        )
+        conn.commit()
+
+    with pytest.raises(ValueError, match="does not match its embedded device key"):
+        provisioning.finalize_admission(root, alice_hex, "ProjectX", proposal_hex)
+
+
+# --------------------------------------------------------------------------- #
+# 11. Committee round 3: forged finalization rows are ignored, not terminal.
+#     They must neither report the proposal finalized nor block ("already
+#     finalized") the legitimate finalization, which -- finalization having no
+#     UNIQUE(subject_record_id) -- is appended alongside the invalid rows.
+# --------------------------------------------------------------------------- #
+
+
+def test_forged_finalization_rows_are_ignored_and_do_not_block(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    carol_hex = provisioning.create_new_participant(root, "Carol")
+    _admit(root, alice_hex, carol_hex, cloud, label="Carol")  # second steward
+    provisioning.set_team_admission_policy(root, alice_hex, "ProjectX", quorum=2)
+    _push(alice_sync, cloud)
+
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+    )
+    _push(alice_sync, cloud)
+    acceptance = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+    proposals = provisioning.list_invitations(root, alice_hex, "ProjectX")
+    proposal_hex = next(p["id"] for p in proposals if p["status"] == "awaiting_quorum")
+    proposal_id = bytes.fromhex(proposal_hex)
+
+    # Carol's clean replica, before Alice's gets poisoned.
+    carol_sync = root / "Participants" / carol_hex / "ProjectX" / "Sync"
+    shutil.copy2(alice_sync / "core.db", carol_sync / "core.db")
+
+    db = alice_sync / "core.db"
+
+    def _insert_forged_finalizations():
+        # Variant 1: in the inviter's (Alice's) name, everything consistent
+        # except the signature, which is an attacker key's.
+        with sqlite3.connect(str(db)) as conn:
+            alice_teammate_id, alice_device_key_id = conn.execute(
+                "SELECT m.id, d.device_key_id FROM teammate m "
+                "JOIN team_device d ON d.teammate_id = m.id WHERE m.display_name = 'Alice'"
+            ).fetchone()
+            proposal_digest, snapshot_json = conn.execute(
+                "SELECT constitution_digest, constitution_snapshot_json "
+                "FROM admission_proposal WHERE record_id = ?",
+                (proposal_id,),
+            ).fetchone()
+            subject_digest = conn.execute(
+                "SELECT subject_digest FROM endorsement WHERE subject_record_id = ?",
+                (proposal_id,),
+            ).fetchone()[0]
+            _attacker_key, attacker_private = generate_key_pair(ProtectionLevel.DAILY)
+            now = provisioning._now_iso()
+            forged_signed = {
+                **provisioning._record_envelope_fields(
+                    record_type="finalization",
+                    author_teammate_id=alice_teammate_id,
+                    author_device_key_id=alice_device_key_id,
+                    created_at=now,
+                    anchor_commit=None,
+                    constitution_digest=proposal_digest,
+                ),
+                "subject_record_id": proposal_id.hex(),
+                "subject_digest": subject_digest.hex(),
+                "endorsement_count": 2,
+            }
+            forged_canonical = canonical_constitution_bytes(forged_signed)
+            conn.execute(
+                "INSERT INTO finalization ("
+                "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+                "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+                "subject_record_id, subject_digest, endorsement_count, signature) "
+                "VALUES (?, 'finalization', ?, ?, ?, NULL, ?, ?, 1, ?, ?, 2, ?)",
+                (
+                    derive_record_id(forged_canonical),
+                    alice_teammate_id,
+                    alice_device_key_id,
+                    now,
+                    proposal_digest,
+                    snapshot_json,
+                    proposal_id,
+                    subject_digest,
+                    sign_constitution_record(attacker_private, forged_canonical),
+                ),
+            )
+            conn.commit()
+
+        # Variant 2: a *validly signed* finalization authored by Carol, who is
+        # a steward but not the proposal's author -- the inviter-only rule
+        # makes it non-terminal.
+        carol_private, carol_public = provisioning.get_current_team_device_key(
+            root, carol_hex, "ProjectX"
+        )
+        engine = provisioning._sqlite_engine(db)
+        try:
+            with engine.begin() as conn:
+                carol_teammate_id = conn.execute(
+                    provisioning.text("SELECT id FROM teammate WHERE display_name = 'Carol'")
+                ).fetchone()[0]
+                provisioning._append_finalization(
+                    conn,
+                    proposal_row=provisioning._load_proposal_row(conn, proposal_id),
+                    finalizer_teammate_id=carol_teammate_id,
+                    author_private_key=carol_private,
+                    author_public_key=carol_public,
+                    anchor_commit=None,
+                    endorsement_count=2,
+                )
+        finally:
+            engine.dispose()
+
+        # Variant 3 (crossed author/device): claims Alice as author but names
+        # -- and is validly signed by -- Carol's device. Only the
+        # device-belongs-to-teammate binding against the proposal snapshot
+        # rejects it.
+        carol_device_key_id = key_id_from_public(carol_public)
+        with sqlite3.connect(str(db)) as conn:
+            alice_teammate_id = conn.execute(
+                "SELECT id FROM teammate WHERE display_name = 'Alice'"
+            ).fetchone()[0]
+            proposal_digest, snapshot_json = conn.execute(
+                "SELECT constitution_digest, constitution_snapshot_json "
+                "FROM admission_proposal WHERE record_id = ?",
+                (proposal_id,),
+            ).fetchone()
+            subject_digest = conn.execute(
+                "SELECT subject_digest FROM endorsement WHERE subject_record_id = ?",
+                (proposal_id,),
+            ).fetchone()[0]
+            now = provisioning._now_iso()
+            crossed_signed = {
+                **provisioning._record_envelope_fields(
+                    record_type="finalization",
+                    author_teammate_id=alice_teammate_id,
+                    author_device_key_id=carol_device_key_id,
+                    created_at=now,
+                    anchor_commit=None,
+                    constitution_digest=proposal_digest,
+                ),
+                "subject_record_id": proposal_id.hex(),
+                "subject_digest": subject_digest.hex(),
+                "endorsement_count": 2,
+            }
+            crossed_canonical = canonical_constitution_bytes(crossed_signed)
+            conn.execute(
+                "INSERT INTO finalization ("
+                "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+                "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+                "subject_record_id, subject_digest, endorsement_count, signature) "
+                "VALUES (?, 'finalization', ?, ?, ?, NULL, ?, ?, 1, ?, ?, 2, ?)",
+                (
+                    derive_record_id(crossed_canonical),
+                    alice_teammate_id,
+                    carol_device_key_id,
+                    now,
+                    proposal_digest,
+                    snapshot_json,
+                    proposal_id,
+                    subject_digest,
+                    sign_constitution_record(carol_private, crossed_canonical),
+                ),
+            )
+            conn.commit()
+
+    _insert_forged_finalizations()
+
+    # Neither forged row is terminal: the proposal still awaits quorum...
+    statuses = {
+        p["id"]: p["status"] for p in provisioning.list_invitations(root, alice_hex, "ProjectX")
+    }
+    assert statuses[proposal_hex] == "awaiting_quorum"
+    # ...and the block reason is the honest one (quorum), not "already finalized".
+    with pytest.raises(ValueError, match="quorum"):
+        provisioning.finalize_admission(root, alice_hex, "ProjectX", proposal_hex)
+    with sqlite3.connect(str(db)) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM teammate WHERE display_name = 'Bob'"
+        ).fetchone()[0] == 0
+
+    # Meet quorum for real; the legitimate finalization coexists with the
+    # forged rows (no UNIQUE on subject_record_id) and wins.
+    provisioning.endorse_admission(root, carol_hex, "ProjectX", proposal_hex)
+    shutil.copy2(carol_sync / "core.db", alice_sync / "core.db")
+    _insert_forged_finalizations()
+    provisioning.finalize_admission(root, alice_hex, "ProjectX", proposal_hex)
+
+    statuses = {
+        p["id"]: p["status"] for p in provisioning.list_invitations(root, alice_hex, "ProjectX")
+    }
+    assert statuses[proposal_hex] == "finalized"
+    with sqlite3.connect(str(db)) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM finalization WHERE subject_record_id = ?", (proposal_id,)
+        ).fetchone()[0] == 4
+        assert conn.execute(
+            "SELECT COUNT(*) FROM teammate WHERE display_name = 'Bob'"
+        ).fetchone()[0] == 1
+
+
+# --------------------------------------------------------------------------- #
+# 12. Crossed author/device on the proposal itself: a row claiming Alice as
+#     author but validly signed by Carol's device is rejected -- the device
+#     must belong to the claimed teammate (bound via team_device, since the
+#     proposal's own snapshot is self-referential).
+# --------------------------------------------------------------------------- #
+
+
+def test_proposal_claiming_another_teammates_authorship_is_rejected(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    carol_hex = provisioning.create_new_participant(root, "Carol")
+    _admit(root, alice_hex, carol_hex, cloud, label="Carol")
+
+    team_id = provisioning._team_row(root, alice_hex, "ProjectX")[0]
+    carol_private, carol_public = provisioning.get_current_team_device_key(
+        root, carol_hex, "ProjectX"
+    )
+    carol_device_key_id = key_id_from_public(carol_public)
+    mode_plan = provisioning.mode_plan_for_preset("steward")
+    nonce = b"\x01" * 16
+    expires_at = "2999-01-01T00:00:00+00:00"
+
+    engine = provisioning._sqlite_engine(alice_sync / "core.db")
+    try:
+        with engine.begin() as conn:
+            alice_teammate_id = conn.execute(
+                provisioning.text("SELECT id FROM teammate WHERE display_name = 'Alice'")
+            ).fetchone()[0]
+            snapshot = provisioning._constitution_snapshot(conn)
+            digest = provisioning._constitution_digest(snapshot)
+            now = provisioning._now_iso()
+            invitee_teammate_id = provisioning.uuid7()
+            signed = {
+                **provisioning._record_envelope_fields(
+                    record_type="admission_proposal",
+                    author_teammate_id=alice_teammate_id,   # claimed author
+                    author_device_key_id=carol_device_key_id,  # Carol's device
+                    created_at=now,
+                    anchor_commit=None,
+                    constitution_digest=digest,
+                ),
+                "nonce": nonce.hex(),
+                "team_id": team_id.hex(),
+                "invitee_teammate_id": invitee_teammate_id.hex(),
+                "invitee_label_commitment": None,
+                "expires_at": expires_at,
+                "mode_plan": mode_plan,
+            }
+            canonical = canonical_constitution_bytes(signed)
+            # In-memory row tuple in _load_proposal_row column order: internally
+            # self-consistent (record_id and signature both valid) -- only the
+            # device-to-teammate binding is wrong.
+            forged_row = (
+                derive_record_id(canonical),
+                alice_teammate_id,
+                carol_device_key_id,
+                now,
+                None,
+                digest,
+                provisioning._json_dumps_sorted(snapshot),
+                nonce,
+                team_id,
+                invitee_teammate_id,
+                None,
+                expires_at,
+                sign_constitution_record(carol_private, canonical),
+                None,
+                provisioning._json_dumps_sorted(mode_plan),
+            )
+            with pytest.raises(ValueError, match="does not belong to the author teammate"):
+                provisioning._verify_proposal_row(conn, forged_row)
+    finally:
+        engine.dispose()
+
+
+# --------------------------------------------------------------------------- #
+# 13. Committee round 5: finalization status verifies the proposal row itself
+#     before trusting its author/snapshot. An in-place tamper of the proposal
+#     (same record_id PK, swapped author) re-roots the device binding at
+#     attacker-chosen data; without _verify_proposal_row in the status path, a
+#     validly signed finalization from the new "author" reads as terminal.
+# --------------------------------------------------------------------------- #
+
+
+def test_tampered_proposal_author_does_not_enable_finalization(playground_dir):
+    root = pathlib.Path(playground_dir)
+    alice_hex, bob_hex, cloud, alice_sync = _setup_team(root)
+    carol_hex = provisioning.create_new_participant(root, "Carol")
+    _admit(root, alice_hex, carol_hex, cloud, label="Carol")  # insider attacker
+    provisioning.set_team_admission_policy(root, alice_hex, "ProjectX", quorum=2)
+    _push(alice_sync, cloud)
+
+    token = provisioning.create_invitation(
+        root, alice_hex, "ProjectX",
+        {"protocol": "localfolder", "url": str(cloud)},
+        invitee_label="Bob",
+    )
+    _push(alice_sync, cloud)
+    acceptance = provisioning.accept_invitation(
+        root, bob_hex, token, inviter_remote=CS.LocalFolderRemote(str(cloud))
+    )
+    provisioning.complete_invitation_acceptance(root, alice_hex, "ProjectX", acceptance)
+    proposals = provisioning.list_invitations(root, alice_hex, "ProjectX")
+    proposal_hex = next(p["id"] for p in proposals if p["status"] == "awaiting_quorum")
+    proposal_id = bytes.fromhex(proposal_hex)
+
+    # In-place tamper: same record_id PK (FKs intact), author swapped to Carol.
+    # The proposal's stored snapshot already lists Carol's device (she is a
+    # teammate), so the single-column swap suffices for an insider; an outsider
+    # would additionally rewrite digest+snapshot to a self-consistent crafted
+    # pair -- the same record_id-vs-canonical check catches both.
+    db = alice_sync / "core.db"
+    carol_private, carol_public = provisioning.get_current_team_device_key(
+        root, carol_hex, "ProjectX"
+    )
+    carol_device_key_id = key_id_from_public(carol_public)
+    with sqlite3.connect(str(db)) as conn:
+        carol_teammate_id = conn.execute(
+            "SELECT id FROM teammate WHERE display_name = 'Carol'"
+        ).fetchone()[0]
+        conn.execute(
+            "UPDATE admission_proposal SET author_teammate_id = ? WHERE record_id = ?",
+            (carol_teammate_id, proposal_id),
+        )
+        proposal_digest = conn.execute(
+            "SELECT constitution_digest FROM admission_proposal WHERE record_id = ?",
+            (proposal_id,),
+        ).fetchone()[0]
+        snapshot_json = conn.execute(
+            "SELECT constitution_snapshot_json FROM admission_proposal WHERE record_id = ?",
+            (proposal_id,),
+        ).fetchone()[0]
+        subject_digest = conn.execute(
+            "SELECT subject_digest FROM endorsement WHERE subject_record_id = ?",
+            (proposal_id,),
+        ).fetchone()[0]
+        # Carol finalizes "her own" proposal: valid signature, valid device,
+        # author matches the (tampered) proposal author.
+        now = provisioning._now_iso()
+        signed = {
+            **provisioning._record_envelope_fields(
+                record_type="finalization",
+                author_teammate_id=carol_teammate_id,
+                author_device_key_id=carol_device_key_id,
+                created_at=now,
+                anchor_commit=None,
+                constitution_digest=proposal_digest,
+            ),
+            "subject_record_id": proposal_id.hex(),
+            "subject_digest": subject_digest.hex(),
+            "endorsement_count": 2,
+        }
+        canonical = canonical_constitution_bytes(signed)
+        conn.execute(
+            "INSERT INTO finalization ("
+            "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+            "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+            "subject_record_id, subject_digest, endorsement_count, signature) "
+            "VALUES (?, 'finalization', ?, ?, ?, NULL, ?, ?, 1, ?, ?, 2, ?)",
+            (
+                derive_record_id(canonical),
+                carol_teammate_id,
+                carol_device_key_id,
+                now,
+                proposal_digest,
+                snapshot_json,
+                proposal_id,
+                subject_digest,
+                sign_constitution_record(carol_private, canonical),
+            ),
+        )
+        conn.commit()
+
+    # The tampered proposal fails record_id-vs-canonical verification, so the
+    # finalization -- however well signed -- is not terminal.
+    statuses = {
+        p["id"]: p["status"] for p in provisioning.list_invitations(root, alice_hex, "ProjectX")
+    }
+    assert statuses[proposal_hex] == "awaiting_quorum"
+    with pytest.raises(ValueError, match="Only the inviter|record_id does not match"):
+        provisioning.finalize_admission(root, alice_hex, "ProjectX", proposal_hex)
+    with sqlite3.connect(str(db)) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM teammate WHERE display_name = 'Bob'"
+        ).fetchone()[0] == 0

--- a/packages/small-sea-manager/tests/test_hub_invitation_flow.py
+++ b/packages/small-sea-manager/tests/test_hub_invitation_flow.py
@@ -157,7 +157,7 @@ def test_invitation_flow_via_hub(playground_dir, minio_server_gen):
 
     assert isinstance(acceptance_b64, str)
     acceptance = json.loads(base64.b64decode(acceptance_b64).decode())
-    bob_teammate_id_hex = acceptance["acceptor_teammate_id"]
+    bob_teammate_id_hex = acceptance["author_teammate_id"]
 
     # ---- Bob: push accepted team repo via Hub ----
     bob_team_token = _open_session(http, "Bob", "ProjectX")

--- a/packages/small-sea-manager/tests/test_invitation.py
+++ b/packages/small-sea-manager/tests/test_invitation.py
@@ -216,11 +216,11 @@ def test_full_invitation_flow(playground_dir, minio_server_gen):
     assert isinstance(acceptance_b64, str)
 
     acceptance = json.loads(base64.b64decode(acceptance_b64).decode())
-    bob_teammate_id_hex = acceptance["acceptor_teammate_id"]
+    bob_teammate_id_hex = acceptance["author_teammate_id"]
     assert bob_teammate_id_hex != bob_hex
     assert len(bob_teammate_id_hex) == 32
     assert acceptance["team_id"] == token_data["team_id"]
-    assert len(acceptance["acceptor_device_public_key"]) == 64
+    assert len(acceptance["invitee_device_public_key"]) == 64
     assert "acceptor_sender_key" not in acceptance
     assert "acceptor_cloud" not in acceptance
     assert "acceptor_bucket" not in acceptance
@@ -247,7 +247,7 @@ def test_full_invitation_flow(playground_dir, minio_server_gen):
     # _push_via_hub helper ran for Bob here.
     assert len(bob_ann_rows) == 1
     bob_ann = TeammateBerthStorageAnnouncement(*bob_ann_rows[0])
-    bob_device_public_key = bytes.fromhex(acceptance["acceptor_device_public_key"])
+    bob_device_public_key = bytes.fromhex(acceptance["invitee_device_public_key"])
     assert bob_ann.signer_key_id == key_id_from_public(bob_device_public_key)
     assert verify_teammate_berth_storage_announcement_signature(
         bob_ann, bob_device_public_key
@@ -288,18 +288,18 @@ def test_full_invitation_flow(playground_dir, minio_server_gen):
     bob_team_device_row = next(
         row for row in team_devices if row[0] == bytes.fromhex(bob_teammate_id_hex)
     )
-    assert bob_team_device_row[1] == bytes.fromhex(acceptance["acceptor_device_key_id"])
-    assert bob_team_device_row[2] == bytes.fromhex(acceptance["acceptor_device_public_key"])
+    assert bob_team_device_row[1] == bytes.fromhex(acceptance["author_device_key_id"])
+    assert bob_team_device_row[2] == bytes.fromhex(acceptance["invitee_device_public_key"])
 
     bob_cert_row = aconn.execute(
         "SELECT cert_id, cert_type, subject_key_id, subject_public_key, issuer_key_id, "
         "issuer_teammate_id, issued_at, claims, signature "
         "FROM key_certificate WHERE subject_public_key = ?",
-        (bytes.fromhex(acceptance["acceptor_device_public_key"]),),
+        (bytes.fromhex(acceptance["invitee_device_public_key"]),),
     ).fetchone()
     assert bob_cert_row is not None
     assert bob_cert_row[1] == "membership"
-    assert bob_cert_row[3] == bytes.fromhex(acceptance["acceptor_device_public_key"])
+    assert bob_cert_row[3] == bytes.fromhex(acceptance["invitee_device_public_key"])
     assert bob_cert_row[5] == bytes.fromhex(alice_teammate_id_hex)
     assert json.loads(bob_cert_row[7])["teammate_id"] == bob_teammate_id_hex
     bob_membership_cert = provisioning._deserialize_cert(
@@ -325,7 +325,7 @@ def test_full_invitation_flow(playground_dir, minio_server_gen):
         team_id=bytes.fromhex(token_data["team_id"]),
         issuer_teammate_id=bytes.fromhex(alice_teammate_id_hex),
         admitted_teammate_id=bytes.fromhex(bob_teammate_id_hex),
-        subject_public_key=bytes.fromhex(acceptance["acceptor_device_public_key"]),
+        subject_public_key=bytes.fromhex(acceptance["invitee_device_public_key"]),
     )
 
     roles = aconn.execute("SELECT teammate_id, role FROM berth_role").fetchall()
@@ -373,7 +373,7 @@ def test_full_invitation_flow(playground_dir, minio_server_gen):
     assert teams[0]["self_in_team"] == bytes.fromhex(bob_teammate_id_hex)
     alice_sender_device_key_id = key_id_from_public(alice_device_public_key)
     bob_sender_device_key_id = key_id_from_public(
-        bytes.fromhex(acceptance["acceptor_device_public_key"])
+        bytes.fromhex(acceptance["invitee_device_public_key"])
     )
 
     with pytest.raises(sqlite3.OperationalError):

--- a/packages/small-sea-manager/tests/test_merge_conflict.py
+++ b/packages/small-sea-manager/tests/test_merge_conflict.py
@@ -98,7 +98,7 @@ def test_concurrent_invitations_merge(playground_dir):
     # 8. Assert: device 2's core.db has BOTH Bob and Carol admission proposals
     conn2 = sqlite3.connect(str(team_sync_2 / "core.db"))
     invitations_2 = conn2.execute(
-        "SELECT invitee_label FROM admission_proposal ORDER BY invitee_label"
+        "SELECT invitee_label_payload FROM admission_proposal ORDER BY invitee_label_payload"
     ).fetchall()
     conn2.close()
     labels_2 = {row[0] for row in invitations_2}
@@ -119,7 +119,7 @@ def test_concurrent_invitations_merge(playground_dir):
     # 10. Assert: device 1 also has both proposals
     conn1 = sqlite3.connect(str(team_sync_1 / "core.db"))
     invitations_1 = conn1.execute(
-        "SELECT invitee_label FROM admission_proposal ORDER BY invitee_label"
+        "SELECT invitee_label_payload FROM admission_proposal ORDER BY invitee_label_payload"
     ).fetchall()
     conn1.close()
     labels_1 = {row[0] for row in invitations_1}
@@ -141,53 +141,51 @@ def _create_invitation_on_device(team_sync_dir, invitee_label):
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     teammate_ids = [row[0].hex() for row in conn.execute("SELECT id FROM teammate ORDER BY id").fetchall()]
-    steward_ids = [
-        row[0].hex()
-        for row in conn.execute(
-            """
-            SELECT br.teammate_id
-            FROM berth_role br
-            JOIN team_app_berth tab ON tab.id = br.berth_id
-            JOIN app a ON a.id = tab.app_id
-            WHERE a.name = 'SmallSeaCollectiveCore' AND br.role = 'read-write'
-            ORDER BY br.teammate_id
-            """
-        ).fetchall()
-    ]
     teammate_devices: dict[str, list[str]] = {teammate_id_hex: [] for teammate_id_hex in teammate_ids}
     for teammate_id, device_key_id in conn.execute(
         "SELECT teammate_id, device_key_id FROM team_device ORDER BY teammate_id, device_key_id"
     ).fetchall():
         teammate_devices.setdefault(teammate_id.hex(), []).append(device_key_id.hex())
-    governance_snapshot = {
-        "stewards": steward_ids,
+    berth_roles = [
+        {"teammate_id": row[0].hex(), "berth_id": row[1].hex(), "role": row[2]}
+        for row in conn.execute(
+            "SELECT teammate_id, berth_id, role FROM berth_role ORDER BY teammate_id, berth_id"
+        ).fetchall()
+    ]
+    constitution_snapshot = {
         "teammates": teammate_ids,
         "teammate_devices": teammate_devices,
+        "berth_roles": berth_roles,
     }
-    governance_digest = provisioning._governance_digest(governance_snapshot)
+    constitution_digest = provisioning._constitution_digest(constitution_snapshot)
     # The team DB is scoped to one team and does not persist a team_id column.
     # For this merge test we only need a stable non-null value to exercise
     # concurrent append-only proposal rows through the sqlite merge driver.
+    # The record's signature/device-key fields are not verified here.
     pseudo_team_id = conn.execute("SELECT id FROM app LIMIT 1").fetchone()["id"]
     team_row = conn.execute("SELECT id FROM teammate ORDER BY id LIMIT 1").fetchone()
     conn.execute(
         "INSERT INTO admission_proposal ("
-        "proposal_id, nonce, team_id, inviter_teammate_id, invitee_teammate_id, "
-        "invitee_label, role, anchor_commit, governance_digest, governance_snapshot_json, "
-        "state, created_at, expires_at"
-        ") VALUES (?, ?, ?, ?, ?, ?, 'steward', ?, ?, ?, 'awaiting_invitee', ?, ?)",
+        "record_id, record_type, author_teammate_id, author_device_key_id, created_at, "
+        "anchor_commit, constitution_digest, constitution_snapshot_json, schema_version, "
+        "nonce, team_id, invitee_teammate_id, invitee_label_commitment, expires_at, "
+        "signature, invitee_label_payload, mode_plan"
+        ") VALUES (?, 'admission_proposal', ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, NULL, ?, ?, ?, ?)",
         (
             provisioning.uuid7(),
+            team_row["id"],
+            secrets.token_bytes(16),
+            datetime.now(timezone.utc).isoformat(),
+            head_commit,
+            constitution_digest,
+            provisioning._json_dumps_sorted(constitution_snapshot),
             secrets.token_bytes(16),
             pseudo_team_id,
-            team_row["id"],
             provisioning.uuid7(),
-            invitee_label,
-            head_commit,
-            governance_digest,
-            provisioning._json_dumps_sorted(governance_snapshot),
-            datetime.now(timezone.utc).isoformat(),
             provisioning._proposal_expiry(datetime.now(timezone.utc), 7 * 24 * 60 * 60),
+            secrets.token_bytes(64),
+            invitee_label,
+            provisioning._json_dumps_sorted(provisioning.mode_plan_for_preset("steward")),
         ),
     )
     conn.commit()

--- a/packages/small-sea-manager/tests/test_signed_bundles.py
+++ b/packages/small-sea-manager/tests/test_signed_bundles.py
@@ -168,7 +168,7 @@ def test_signed_bundle_roundtrip(playground_dir, minio_server_gen):
 
     # -- Bob: read Alice's latest link via Hub and verify signature --
     acceptance = json.loads(base64.b64decode(acceptance_b64).decode())
-    bob_teammate_id_hex = acceptance["acceptor_teammate_id"]
+    bob_teammate_id_hex = acceptance["author_teammate_id"]
 
     bob_team_token = _open_session(http, "Bob", "ProjectX", mode="passthrough")
     peer_remote = PeerSmallSeaRemote(

--- a/packages/ssc-files/tests/test_hub_sync.py
+++ b/packages/ssc-files/tests/test_hub_sync.py
@@ -150,7 +150,7 @@ def _setup_two_teammate_team(playground_dir, minio_server_gen):
     bob_manager = TeamManager(root, bob_hex, _http_client=http)
     acceptance_b64 = bob_manager.accept_invitation(token_b64)
     acceptance = json.loads(base64.b64decode(acceptance_b64).decode())
-    bob_teammate_id_hex = acceptance["acceptor_teammate_id"]
+    bob_teammate_id_hex = acceptance["author_teammate_id"]
     bob_team_token = _open_session(http, "Bob", "ProjectX")
     bob_files_berth = _session_berth_info(http, bob_team_token)["berth_id"]
     # Match Alice's stable fixture shape for Bob's own app berth.

--- a/packages/ssc-files/tests/test_web_sync.py
+++ b/packages/ssc-files/tests/test_web_sync.py
@@ -133,7 +133,7 @@ def _setup_two_teammate_team(playground_dir, minio_server_gen):
     bob_manager = TeamManager(root, bob_hex, _http_client=http)
     acceptance_b64 = bob_manager.accept_invitation(token_b64)
     acceptance = json.loads(base64.b64decode(acceptance_b64).decode())
-    bob_teammate_id_hex = acceptance["acceptor_teammate_id"]
+    bob_teammate_id_hex = acceptance["author_teammate_id"]
     bob_team_token = _open_session(http, "Bob", "ProjectX")
     bob_files_berth = _session_berth_info(http, bob_team_token)["berth_id"]
     # Match Alice's stable fixture shape for Bob's own app berth.


### PR DESCRIPTION
close #164

Rebuilds the quorum-gated admission flow as four append-only Team Constitution record types on the shared envelope (`wrasse_trust.constitution`): `admission_proposal`, `admission_acceptance` (self-certifying — the schema's one documented exception), `endorsement`, and `finalization` — replacing the mutable proposal state machine and `steward_approval`.
Records are never mutated: status is a computed view, expiry and governance drift are refusals, and only a verified `finalization` row makes a proposal effective.
Endorsements dedupe per teammate, fixing the per-device double-count toward quorum, and the steward/contributor preset becomes a signed per-berth `mode_plan` on the proposal, expanded at finalization into signed `integration_mode_change` records (contributors: `proposal-only` on Core, `automatic` elsewhere, per `architecture.md`).

Records are also verified where they are consumed: quorum counts only endorsements that verify end-to-end, proposal/acceptance/finalization rows are re-verified at decision points, forged finalizations are ignored rather than terminal, and author devices are bound to their claimed teammates. Verification is deliberately one-hop, not chain-of-trust to genesis (#166/#167). Part of #163; unblocks #162.
Pre-alpha: `USER_SCHEMA_VERSION` 62 → 64, no migration.